### PR TITLE
add AV 2D coords visualisation to example

### DIFF
--- a/examples/visualisation/visualisation_config.yaml
+++ b/examples/visualisation/visualisation_config.yaml
@@ -43,7 +43,7 @@ raster_params:
 ## Data loader options
 train_data_loader:
   datasets:
-    - key: "sample_scenes/20200504_competition_sample.zarr"
+    - key: "sample_scenes/sample.zarr"
       scene_indices:
         - -1
   perturb_probability: 0
@@ -53,7 +53,7 @@ train_data_loader:
 
 val_data_loader:
   datasets:
-    - key: "sample_scenes/20200504_competition_sample.zarr"
+    - key: "sample_scenes/sample.zarr"
       scene_indices:
         - -1
   perturb_probability: 0

--- a/examples/visualisation/visualise_data.ipynb
+++ b/examples/visualisation/visualise_data.ipynb
@@ -38,6 +38,7 @@
     "from l5kit.configs import load_config_data\n",
     "from l5kit.visualization import draw_trajectory, TARGET_POINTS_COLOR\n",
     "from l5kit.geometry import transform_points\n",
+    "from tqdm import tqdm\n",
     "\n",
     "import os"
    ]
@@ -108,14 +109,46 @@
    "source": [
     "dm = LocalDataManager()\n",
     "dataset_path = dm.require(cfg[\"train_data_loader\"][\"datasets\"][0][\"key\"])\n",
-    "z = ChunkedStateDataset(dataset_path)\n",
-    "z.open()"
+    "zarr_dataset = ChunkedStateDataset(dataset_path)\n",
+    "zarr_dataset.open()"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Working with the raw data\n",
+    "\n",
+    "`.zarr` files support most of the traditional numpy array operations. In the following cell we iterate over the frames to get a scatter plot of the AV locations."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "indexes = np.linspace(0, len(zarr_dataset.frames) - 1, 10000).astype(np.int)\n",
+    "coords = np.zeros((len(indexes), 2))\n",
+    "for idx_coord, idx_data in enumerate(tqdm(indexes, desc=\"getting centroid to plot trajectory\")):\n",
+    "    frame = zarr_dataset.frames[idx_data]\n",
+    "    coords[idx_coord] = frame[\"ego_translation\"][:2]\n",
+    "\n",
+    "\n",
+    "plt.scatter(coords[:, 0], coords[:, 1], marker='.')\n",
+    "axes = plt.gca()\n",
+    "axes.set_xlim([-2500, 1600])\n",
+    "axes.set_ylim([-2500, 1600])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Working with data abstraction\n",
+    "\n",
+    "Even though it's absolutely fine to work with the raw data, we also provide classes that abstract data access to offer an easy way to generate inputs and targets.\n",
+    "\n",
     "### Core Objects\n",
     "Along with the `rasterizer`, our tolkit contains other classes you may want to use while you build your solution. The `dataset` package as an example already implement `PyTorch` ready datasets, so you can hit the ground running and start coding immediately.\n",
     "\n",
@@ -134,7 +167,7 @@
    "outputs": [],
    "source": [
     "rast = build_rasterizer(cfg, dm)\n",
-    "dataset = EgoDataset(cfg, z, rast)"
+    "dataset = EgoDataset(cfg, zarr_dataset, rast)"
    ]
   },
   {
@@ -182,7 +215,7 @@
    "source": [
     "cfg[\"raster_params\"][\"map_type\"] = \"py_satellite\"\n",
     "rast = build_rasterizer(cfg, dm)\n",
-    "dataset = EgoDataset(cfg, z, rast)\n",
+    "dataset = EgoDataset(cfg, zarr_dataset, rast)\n",
     "data = dataset[50]\n",
     "\n",
     "im = data[\"image\"].transpose(1, 2, 0)\n",
@@ -209,7 +242,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dataset = AgentDataset(cfg, z, rast)\n",
+    "dataset = AgentDataset(cfg, zarr_dataset, rast)\n",
     "data = dataset[0]\n",
     "\n",
     "im = data[\"image\"].transpose(1, 2, 0)\n",
@@ -262,7 +295,7 @@
     " \n",
     "cfg[\"raster_params\"][\"map_type\"] = \"py_satellite\"\n",
     "rast = build_rasterizer(cfg, dm)\n",
-    "dataset = EgoDataset(cfg, z, rast)\n",
+    "dataset = EgoDataset(cfg, zarr_dataset, rast)\n",
     "scene_idx = 1\n",
     "indexes = dataset.get_scene_indices(scene_idx)\n",
     "images = []\n",
@@ -296,15 +329,15 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.9"
+   "version": "3.6.8"
   },
   "pycharm": {
    "stem_cell": {
     "cell_type": "raw",
-    "source": [],
     "metadata": {
      "collapsed": false
-    }
+    },
+    "source": []
    }
   }
  },

--- a/examples/visualisation/visualise_data.ipynb
+++ b/examples/visualisation/visualise_data.ipynb
@@ -128,9 +128,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "indexes = np.linspace(0, len(zarr_dataset.frames) - 1, 10000).astype(np.int)\n",
-    "coords = np.zeros((len(indexes), 2))\n",
-    "for idx_coord, idx_data in enumerate(tqdm(indexes, desc=\"getting centroid to plot trajectory\")):\n",
+    "frames = zarr_dataset.frames\n",
+    "coords = np.zeros((len(frames), 2))\n",
+    "for idx_coord, idx_data in enumerate(tqdm(range(len(frames)), desc=\"getting centroid to plot trajectory\")):\n",
     "    frame = zarr_dataset.frames[idx_data]\n",
     "    coords[idx_coord] = frame[\"ego_translation\"][:2]\n",
     "\n",


### PR DESCRIPTION
Add 2D scatter plot of AV coordinates (from zarr `frames`) in the visualisation example.
This should print something like this:
![Screenshot 2020-06-22 at 13 42 27](https://user-images.githubusercontent.com/27865235/85318389-325e9000-b4c0-11ea-8f4e-6429c186ccdc.png)
