### PR TITLE
Ensure fixed shape array when history!=0, fix tests

### DIFF
--- a/l5kit/l5kit/rasterization/box_rasterizer.py
+++ b/l5kit/l5kit/rasterization/box_rasterizer.py
@@ -119,8 +119,8 @@ class BoxRasterizer(Rasterizer):
         )
 
         # this ensures we always end up with fixed size arrays, +1 is because current time is also in the history
-        agents_im = np.zeros((*self.raster_size, self.history_num_frames + 1), dtype=np.uint8)
-        ego_im = np.zeros((*self.raster_size, self.history_num_frames + 1), dtype=np.uint8)
+        agents_images = np.zeros((*self.raster_size, self.history_num_frames + 1), dtype=np.uint8)
+        ego_images = np.zeros((*self.raster_size, self.history_num_frames + 1), dtype=np.uint8)
 
         for i, frame in enumerate(history_frames):
             agents = filter_agents_by_frame(all_agents, frame)
@@ -129,23 +129,23 @@ class BoxRasterizer(Rasterizer):
             av_agent = get_ego_as_agent(frame).astype(agents.dtype)
 
             if agent is None:
-                im = draw_boxes(self.raster_size, world_to_image_space, agents, 255)
-                im_ego = draw_boxes(self.raster_size, world_to_image_space, av_agent, 255)
+                agents_image = draw_boxes(self.raster_size, world_to_image_space, agents, 255)
+                ego_image = draw_boxes(self.raster_size, world_to_image_space, av_agent, 255)
             else:
                 agent_ego = filter_agents_by_track_id(agents, agent["track_id"])
                 if len(agent_ego) == 0:  # agent not in this history frame
-                    im = draw_boxes(self.raster_size, world_to_image_space, np.append(agents, av_agent), 255)
-                    im_ego = np.zeros_like(im)
+                    agents_image = draw_boxes(self.raster_size, world_to_image_space, np.append(agents, av_agent), 255)
+                    ego_image = np.zeros_like(agents_image)
                 else:  # add av to agents and remove the agent from agents
                     agents = agents[agents != agent_ego[0]]
-                    im = draw_boxes(self.raster_size, world_to_image_space, np.append(agents, av_agent), 255)
-                    im_ego = draw_boxes(self.raster_size, world_to_image_space, agent_ego, 255)
+                    agents_image = draw_boxes(self.raster_size, world_to_image_space, np.append(agents, av_agent), 255)
+                    ego_image = draw_boxes(self.raster_size, world_to_image_space, agent_ego, 255)
 
-            agents_im[..., i] = im
-            ego_im[..., i] = im_ego
+            agents_images[..., i] = agents_image
+            ego_images[..., i] = ego_image
 
         # combine such that the image consists of [agent_t, agent_t-1, agent_t-2, ego_t, ego_t-1, ego_t-2]
-        out_im = np.concatenate((agents_im, ego_im), -1)
+        out_im = np.concatenate((agents_images, ego_images), -1)
 
         return out_im.astype(np.float32) / 255
 

--- a/l5kit/l5kit/rasterization/box_rasterizer.py
+++ b/l5kit/l5kit/rasterization/box_rasterizer.py
@@ -77,6 +77,7 @@ class BoxRasterizer(Rasterizer):
         pixel_size: np.ndarray,
         ego_center: np.ndarray,
         filter_agents_threshold: float,
+        history_num_frames: int,
     ):
         """
 
@@ -85,12 +86,14 @@ class BoxRasterizer(Rasterizer):
             pixel_size (np.ndarray): Dimensions of one pixel in the real world
             ego_center (np.ndarray): Center of ego in the image, [0.5,0.5] would be in the image center.
             filter_agents_threshold (float): Value between 0 and 1 used to filter uncertain agent detections
+            history_num_frames (int): Number of frames to rasterise in the past
         """
         super(BoxRasterizer, self).__init__()
         self.raster_size = raster_size
         self.pixel_size = pixel_size
         self.ego_center = ego_center
         self.filter_agents_threshold = filter_agents_threshold
+        self.history_num_frames = history_num_frames
 
     def rasterize(
         self, history_frames: np.ndarray, all_agents: np.ndarray, agent: Optional[np.ndarray] = None
@@ -115,8 +118,9 @@ class BoxRasterizer(Rasterizer):
             ego_center_in_image_ratio=self.ego_center,
         )
 
-        agents_im = []
-        ego_im = []
+        # this ensure we always end up with fixed size arrays, +1 is because cur time in also in history
+        agents_im = np.zeros((*self.raster_size, self.history_num_frames + 1), dtype=np.uint8)
+        ego_im = np.zeros((*self.raster_size, self.history_num_frames + 1), dtype=np.uint8)
 
         for i, frame in enumerate(history_frames):
             agents = filter_agents_by_frame(all_agents, frame)
@@ -137,11 +141,11 @@ class BoxRasterizer(Rasterizer):
                     im = draw_boxes(self.raster_size, world_to_image_space, np.append(agents, av_agent), 255)
                     im_ego = draw_boxes(self.raster_size, world_to_image_space, agent_ego, 255)
 
-            agents_im.append(im)
-            ego_im.append(im_ego)
+            agents_im[..., i] = im
+            ego_im[..., i] = im_ego
 
         # combine such that the image consists of [agent_t, agent_t-1, agent_t-2, ego_t, ego_t-1, ego_t-2]
-        out_im = np.stack(agents_im + ego_im, -1)
+        out_im = np.concatenate((agents_im, ego_im), -1)
 
         return out_im.astype(np.float32) / 255
 

--- a/l5kit/l5kit/rasterization/box_rasterizer.py
+++ b/l5kit/l5kit/rasterization/box_rasterizer.py
@@ -118,7 +118,7 @@ class BoxRasterizer(Rasterizer):
             ego_center_in_image_ratio=self.ego_center,
         )
 
-        # this ensure we always end up with fixed size arrays, +1 is because cur time in also in history
+        # this ensures we always end up with fixed size arrays, +1 is because current time is also in the history
         agents_im = np.zeros((*self.raster_size, self.history_num_frames + 1), dtype=np.uint8)
         ego_im = np.zeros((*self.raster_size, self.history_num_frames + 1), dtype=np.uint8)
 

--- a/l5kit/l5kit/rasterization/factory.py
+++ b/l5kit/l5kit/rasterization/factory.py
@@ -62,6 +62,7 @@ def build_rasterizer(cfg: dict, data_manager: DataManager) -> Rasterizer:
     pixel_size = np.array(raster_cfg["pixel_size"])
     ego_center = np.array(raster_cfg["ego_center"])
     filter_agents_threshold = raster_cfg["filter_agents_threshold"]
+    history_num_frames = cfg["model_params"]["history_num_frames"]
 
     if map_type in ["py_satellite", "satellite_rgb"]:
         sat_image, meta = _load_image_and_metadata(raster_cfg["satellite_map_key"], data_manager)
@@ -69,14 +70,22 @@ def build_rasterizer(cfg: dict, data_manager: DataManager) -> Rasterizer:
         pose_to_ecef = load_pose_to_ecef()
 
         map_to_sat = np.matmul(ecef_to_sat, pose_to_ecef)
-        return SatBoxRasterizer(raster_size, pixel_size, ego_center, filter_agents_threshold, sat_image, map_to_sat)
+        return SatBoxRasterizer(
+            raster_size, pixel_size, ego_center, filter_agents_threshold, history_num_frames, sat_image, map_to_sat
+        )
     elif map_type == "py_semantic":
         semantic_map_filepath = data_manager.require(raster_cfg["semantic_map_key"])
         semantic_map = load_semantic_map(semantic_map_filepath)
         pose_to_ecef = load_pose_to_ecef()
 
         return SemBoxRasterizer(
-            raster_size, pixel_size, ego_center, filter_agents_threshold, semantic_map, pose_to_ecef
+            raster_size,
+            pixel_size,
+            ego_center,
+            filter_agents_threshold,
+            history_num_frames,
+            semantic_map,
+            pose_to_ecef,
         )
     else:
         raise NotImplementedError(f"Rasterizer for map type {map_type} is not supported.")

--- a/l5kit/l5kit/rasterization/sat_box_rasterizer.py
+++ b/l5kit/l5kit/rasterization/sat_box_rasterizer.py
@@ -18,6 +18,7 @@ class SatBoxRasterizer(Rasterizer):
         pixel_size: np.ndarray,
         ego_center: np.ndarray,
         filter_agents_threshold: float,
+        history_num_frames: int,
         map_im: np.ndarray,
         map_to_sat: np.ndarray,
         interpolation: int = cv2.INTER_LINEAR,
@@ -27,11 +28,13 @@ class SatBoxRasterizer(Rasterizer):
         self.pixel_size = pixel_size
         self.ego_center = ego_center
         self.filter_agents_threshold = filter_agents_threshold
+        self.history_num_frames = history_num_frames
+
         self.map_im = map_im
         self.map_to_sat = map_to_sat
         self.interpolation = interpolation
 
-        self.box_rast = BoxRasterizer(raster_size, pixel_size, ego_center, filter_agents_threshold)
+        self.box_rast = BoxRasterizer(raster_size, pixel_size, ego_center, filter_agents_threshold, history_num_frames)
         self.sat_rast = SatelliteRasterizer(raster_size, pixel_size, ego_center, map_im, map_to_sat, interpolation)
 
     def rasterize(

--- a/l5kit/l5kit/rasterization/sem_box_rasterizer.py
+++ b/l5kit/l5kit/rasterization/sem_box_rasterizer.py
@@ -17,6 +17,7 @@ class SemBoxRasterizer(Rasterizer):
         pixel_size: np.ndarray,
         ego_center: np.ndarray,
         filter_agents_threshold: float,
+        history_num_frames: int,
         semantic_map: dict,
         pose_to_ecef: np.ndarray,
     ):
@@ -25,8 +26,9 @@ class SemBoxRasterizer(Rasterizer):
         self.pixel_size = pixel_size
         self.ego_center = ego_center
         self.filter_agents_threshold = filter_agents_threshold
+        self.history_num_frames = history_num_frames
 
-        self.box_rast = BoxRasterizer(raster_size, pixel_size, ego_center, filter_agents_threshold)
+        self.box_rast = BoxRasterizer(raster_size, pixel_size, ego_center, filter_agents_threshold, history_num_frames)
         self.sat_rast = SemanticRasterizer(raster_size, pixel_size, ego_center, semantic_map, pose_to_ecef)
 
     def rasterize(

--- a/l5kit/l5kit/tests/dataset/dataset_test.py
+++ b/l5kit/l5kit/tests/dataset/dataset_test.py
@@ -60,12 +60,18 @@ def get_rasterizer(rast_name: str, cfg: dict) -> Rasterizer:
     ego_center = np.asarray(cfg["raster_params"]["ego_center"])
 
     if rast_name == "box":
-        return BoxRasterizer(raster_size, pixel_size, ego_center, filter_agents_threshold=-1,)
+        return BoxRasterizer(raster_size, pixel_size, ego_center, filter_agents_threshold=-1, history_num_frames=0)
     elif rast_name == "sat":
         return SatelliteRasterizer(raster_size, pixel_size, ego_center, map_im=map_im, map_to_sat=map_to_sat,)
     elif rast_name == "satbox":
         return SatBoxRasterizer(
-            raster_size, pixel_size, ego_center, filter_agents_threshold=-1, map_im=map_im, map_to_sat=map_to_sat,
+            raster_size,
+            pixel_size,
+            ego_center,
+            filter_agents_threshold=-1,
+            history_num_frames=0,
+            map_im=map_im,
+            map_to_sat=map_to_sat,
         )
     elif rast_name == "sem":
         return SemanticRasterizer(
@@ -79,6 +85,7 @@ def get_rasterizer(rast_name: str, cfg: dict) -> Rasterizer:
             semantic_map=semantic_map,
             pose_to_ecef=pose_to_ecef,
             filter_agents_threshold=-1,
+            history_num_frames=0,
         )
     else:
         raise NotImplementedError
@@ -140,3 +147,25 @@ def test_scene_index_interval(dataset_cls: Callable, scene_idx: int, zarr_datase
     subdata = Subset(dataset, indices)
     for _ in subdata:  # type: ignore
         pass
+
+
+@pytest.mark.parametrize("history_num_frames", [1, 2, 3, 4])
+@pytest.mark.parametrize("dataset_cls", [EgoDataset])  # TODO add Agent when runtime mask is available
+def test_non_zero_history(history_num_frames: int, dataset_cls: Callable, zarr_dataset: ChunkedStateDataset) -> None:
+    cfg = load_config_data("./l5kit/configs/default.yaml")
+    cfg["model_params"]["history_num_frames"] = history_num_frames
+    rast_params = cfg["raster_params"]
+    rast_params["filter_agents_threshold"] = 0.5
+
+    rasterizer = BoxRasterizer(
+        rast_params["raster_size"],
+        np.asarray(rast_params["pixel_size"]),
+        np.asarray(rast_params["ego_center"]),
+        rast_params["filter_agents_threshold"],
+        history_num_frames=history_num_frames,
+    )
+    dataset = dataset_cls(cfg, zarr_dataset, rasterizer, None)
+    indexes = [0, 1, 10, -1]  # because we pad, even the first index should have an (entire black) history
+    for idx in indexes:
+        data = dataset[idx]
+        assert data["image"].shape == (2 * (history_num_frames + 1), *rast_params["raster_size"])

--- a/l5kit/l5kit/tests/rasterization/box_rasterizer_test.py
+++ b/l5kit/l5kit/tests/rasterization/box_rasterizer_test.py
@@ -38,24 +38,26 @@ class BoxRasterizerTest(unittest.TestCase):
         values = [(0.5, 0.5), (0.25, 0.5), (0.75, 0.5), (0.5, 0.25), (0.5, 0.75)]
         for v in values:
             rast = BoxRasterizer(
-                (224, 224), np.asarray((0.25, 0.25)), ego_center=np.asarray(v), filter_agents_threshold=0.0
+                (224, 224),
+                np.asarray((0.25, 0.25)),
+                ego_center=np.asarray(v),
+                filter_agents_threshold=0.0,
+                history_num_frames=0,
             )
             out = rast.rasterize(self.hist_frames, self.dataset.agents)
             assert out[..., -1].sum() > 0
 
     def test_agents_map(self) -> None:
-        rast = BoxRasterizer((224, 224), np.asarray((0.25, 0.25)), np.asarray((0.25, 0.5)), filter_agents_threshold=1)
+        rast = BoxRasterizer((224, 224), np.asarray((0.25, 0.25)), np.asarray((0.25, 0.5)), 1.0, 0)
         out = rast.rasterize(self.hist_frames, self.dataset.agents)
         assert out[..., 0].sum() == 0
 
-        rast = BoxRasterizer(
-            (224, 224), np.asarray((0.25, 0.25)), np.asarray((0.25, 0.5)), filter_agents_threshold=0.0
-        )
+        rast = BoxRasterizer((224, 224), np.asarray((0.25, 0.25)), np.asarray((0.25, 0.5)), 0.0, 0)
         out = rast.rasterize(self.hist_frames, self.dataset.agents)
         assert out[..., 0].sum() > 0
 
     def test_agent_ego(self) -> None:
-        rast = BoxRasterizer((224, 224), np.asarray((0.25, 0.25)), np.asarray((0.25, 0.5)), filter_agents_threshold=-1)
+        rast = BoxRasterizer((224, 224), np.asarray((0.25, 0.25)), np.asarray((0.25, 0.5)), -1, 0)
 
         agents = self.dataset.agents[slice(*self.hist_frames[0]["agent_index_interval"])]
         for ag in agents:
@@ -63,7 +65,9 @@ class BoxRasterizerTest(unittest.TestCase):
             assert out[..., -1].sum() > 0
 
     def test_shape(self) -> None:
-        rast = BoxRasterizer((224, 224), np.asarray((0.25, 0.25)), np.asarray((0.25, 0.5)), filter_agents_threshold=-1)
         hist_length = 10
-        out = rast.rasterize(self.dataset.frames[:hist_length], self.dataset.agents)
-        assert out.shape == (224, 224, 10 * 2)
+        rast = BoxRasterizer(
+            (224, 224), np.asarray((0.25, 0.25)), np.asarray((0.25, 0.5)), -1, history_num_frames=hist_length
+        )
+        out = rast.rasterize(self.dataset.frames[: hist_length + 1], self.dataset.agents)
+        assert out.shape == (224, 224, (hist_length + 1) * 2)

--- a/l5kit/l5kit/tests/rasterization/satbox_rasterizer_test.py
+++ b/l5kit/l5kit/tests/rasterization/satbox_rasterizer_test.py
@@ -16,16 +16,17 @@ class SatBoxRasterizerTest(unittest.TestCase):
         map_to_sat = np.block(
             [[np.eye(3) / 100, np.asarray([[1000], [1000], [1]])], [np.asarray([[0, 0, 0, 1]])]]
         )  # just a translation and scale
+        hist_length = 10
 
         rast = SatBoxRasterizer(
             (224, 224),
             np.asarray((0.25, 0.25)),
             np.asarray((0.25, 0.5)),
             filter_agents_threshold=-1,
+            history_num_frames=hist_length,
             map_im=np.zeros((10000, 10000, 3), dtype=np.uint8),
             map_to_sat=map_to_sat,
         )
 
-        hist_length = 10
-        out = rast.rasterize(self.dataset.frames[:hist_length], self.dataset.agents)
-        assert out.shape == (224, 224, 10 * 2 + 3)
+        out = rast.rasterize(self.dataset.frames[: hist_length + 1], self.dataset.agents)
+        assert out.shape == (224, 224, (hist_length + 1) * 2 + 3)


### PR DESCRIPTION
Now `BoxRasterizer` always returns the same number of channels. If the history is not there (e.g. beginning of a scene) black channels are concatenated to pad the raster output.

It was crashing pytorch because of mismatched sizes in the batch