### PR TITLE
remove spaces from CI names

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,4 +1,4 @@
-name: L5Kit docs
+name: L5Kit-docs
 
 on:
   push:

--- a/.github/workflows/l5kit.yml
+++ b/.github/workflows/l5kit.yml
@@ -1,4 +1,4 @@
-name: L5Kit tests
+name: L5Kit-tests
 
 on:
   push:


### PR DESCRIPTION
Remove space from CI workflows names. Could be required from metaservice.