### PR TITLE
compute_mse now returns step errors

### DIFF
--- a/examples/agent_motion_prediction/agent_motion_prediction.ipynb
+++ b/examples/agent_motion_prediction/agent_motion_prediction.ipynb
@@ -25,6 +25,7 @@
     "from l5kit.geometry import transform_points\n",
     "from l5kit.visualization import PREDICTED_POINTS_COLOR, TARGET_POINTS_COLOR, draw_trajectory\n",
     "from matplotlib import pyplot as plt\n",
+    "from prettytable import PrettyTable\n",
     "\n",
     "import os"
    ]
@@ -103,7 +104,7 @@
     "    # Forward pass\n",
     "    outputs = model(inputs)\n",
     "    loss = criterion(outputs, targets)\n",
-    "    loss = loss.mean()  # weighted average\n",
+    "    loss = loss.mean()\n",
     "    return loss, outputs"
    ]
   },
@@ -167,7 +168,7 @@
     "    model.train()\n",
     "    torch.set_grad_enabled(True)\n",
     "    loss, _ = forward(data, model, device, criterion)\n",
-    "\n",
+    "    \n",
     "    # Backward pass\n",
     "    optimizer.zero_grad()\n",
     "    loss.backward()\n",
@@ -223,7 +224,9 @@
    "metadata": {},
    "source": [
     "### Save results in the competition format and perform evaluation\n",
-    "After the model has predicted trajectories for our evaluation set, we can save them in a `csv` file in the competiion format. To simulate a complete evaluation session we can also save the GT in another `csv` and get the score."
+    "After the model has predicted trajectories for our evaluation set, we can save them in a `csv` file in the competiion format. To simulate a complete evaluation session we can also save the GT in another `csv` and get the scores.\n",
+    "\n",
+    "We will get `future_num_frames` values, corrisponding to the MSE (mean of squared errors) for that timestep."
    ]
   },
   {
@@ -245,7 +248,14 @@
     "                    timestamps=np.concatenate(timestamps),\n",
     "                    agent_ids=np.concatenate(agent_ids))\n",
     "\n",
-    "print(f\"current error is {compute_mse_error_csv(gt_path, pred_path)}\")"
+    "# get a pretty visualisation of the errors\n",
+    "table = PrettyTable(field_names=[\"future step\", \"MSE\"])\n",
+    "table.float_format = \".2\"\n",
+    "steps = range(1, cfg[\"model_params\"][\"future_num_frames\"] + 1)\n",
+    "errors = compute_mse_error_csv(gt_path, pred_path)\n",
+    "for step_idx, step_mse in zip(steps, errors):\n",
+    "    table.add_row([step_idx, step_mse])\n",
+    "print(table)"
    ]
   },
   {
@@ -319,15 +329,15 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.9"
+   "version": "3.6.8"
   },
   "pycharm": {
    "stem_cell": {
     "cell_type": "raw",
-    "source": [],
     "metadata": {
      "collapsed": false
-    }
+    },
+    "source": []
    }
   }
  },

--- a/l5kit/l5kit/evaluation/extract_losses.py
+++ b/l5kit/l5kit/evaluation/extract_losses.py
@@ -59,13 +59,13 @@ Got {len(inference.keys())}"""
         raise ValueError("Error validating csv, see above for details.")
 
     def compute_mse(A: np.ndarray, B: np.ndarray) -> np.ndarray:
-        return ((A - B) ** 2).mean(axis=None)
+        return ((A - B) ** 2).mean(axis=-1)  # reduce coords, keep steps
 
     errors = []
     for key, ground_truth_value in ground_truth.items():
         errors.append(compute_mse(ground_truth_value, inference[key]))
 
-    return np.array(errors).mean(axis=None)
+    return np.array(errors).mean(axis=0)  # reduce samples, keep steps
 
 
 if __name__ == "__main__":

--- a/l5kit/l5kit/tests/evaluation/compute_mse_loss_test.py
+++ b/l5kit/l5kit/tests/evaluation/compute_mse_loss_test.py
@@ -13,7 +13,7 @@ def test_compute_mse_error(tmp_path: Path) -> None:
     export_zarr_to_ground_truth_csv(data, str(tmp_path / "gt1.csv"), 0, 12, 0.5)
     export_zarr_to_ground_truth_csv(data, str(tmp_path / "gt2.csv"), 0, 12, 0.5)
     err = compute_mse_error_csv(str(tmp_path / "gt1.csv"), str(tmp_path / "gt2.csv"))
-    assert err == 0.0
+    assert np.all(err == 0.0)
 
     data_fake = ChunkedStateDataset("")
     data_fake.scenes = np.asarray(data.scenes).copy()
@@ -24,7 +24,7 @@ def test_compute_mse_error(tmp_path: Path) -> None:
 
     export_zarr_to_ground_truth_csv(data_fake, str(tmp_path / "gt3.csv"), 0, 12, 0.5)
     err = compute_mse_error_csv(str(tmp_path / "gt1.csv"), str(tmp_path / "gt3.csv"))
-    assert err > 0.0
+    assert np.any(err > 0.0)
 
     # test invalid conf by removing lines in gt1
     with open(str(tmp_path / "gt4.csv"), "w") as fp:


### PR DESCRIPTION
`compute_mse` can now compute the MSE per step (instead of an average one).

Add table for visualising results in the prediction example, an example follows:

```
+-------------+--------+
| future step |  MSE   |
+-------------+--------+
|      1      |  3.03  |
|      2      | 11.77  |
|      3      | 19.95  |
|      4      | 55.08  |
|      5      | 83.89  |
|      6      | 127.35 |
|      7      | 163.16 |
|      8      | 199.76 |
|      9      | 236.98 |
|      10     | 283.82 |
|      11     | 250.53 |
|      12     | 316.80 |
|      13     | 345.32 |
|      14     | 324.10 |
|      15     | 334.52 |
|      16     | 326.51 |
|      17     | 409.00 |
|      18     | 411.71 |
|      19     | 451.18 |
|      20     | 450.38 |
|      21     | 483.86 |
|      22     | 494.52 |
|      23     | 523.07 |
|      24     | 546.20 |
|      25     | 581.55 |
|      26     | 588.72 |
|      27     | 649.39 |
|      28     | 629.95 |
|      29     | 625.39 |
|      30     | 693.25 |
+-------------+--------+
```