### PR TITLE
Add extension to conf

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -37,6 +37,7 @@ extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.napoleon",
     "sphinx_rtd_theme",
+    "sphinx.ext.githubpages",
     "recommonmark",
 ]
 numpydoc_show_class_members = False


### PR DESCRIPTION
the extension touches `.nojekyll` for us, so we don't have to do it manually when we build docs