### PR TITLE
remove LocalDataManager from select_agents function and module

### DIFF
--- a/l5kit/l5kit/dataset/select_agents.py
+++ b/l5kit/l5kit/dataset/select_agents.py
@@ -12,7 +12,7 @@ import numpy as np
 import zarr
 from tqdm import tqdm
 
-from l5kit.data import ChunkedStateDataset, LocalDataManager
+from l5kit.data import ChunkedStateDataset
 from l5kit.data.filter import _get_label_filter  # TODO expose this without digging
 
 os.environ["BLOSC_NOLOCK"] = "1"  # this is required for multiprocessing
@@ -184,9 +184,6 @@ def select_agents(
     assert th_future_num_frames > 0
 
     # ===== LOAD
-    dm = LocalDataManager()
-    input_folder = dm.require(input_folder)
-
     zarr_dataset = ChunkedStateDataset(path=input_folder)
     zarr_dataset.open()
 


### PR DESCRIPTION
Hi. Thank you for the great dataset and tools!

This PR fixes the bug in the select_agents module.

When I tried to visualize an agent in examples/visualisation/visualise_data.ipynb, I encountered an error as below.

```
cannot find 0_50_0.5 in PATH_TO_MY_DATA/sample_scenes/sample.zarr,
your cfg has loaded history_num_frames=0, future_num_frames=50 and filter_agents_threshold=0.5;
but those values don't have a match among the agents_mask in the zarr
Mask will now be generated for these parameters.
PATH_TO_MY_DATA/sample_scenes/sample.zarr is not present in local data folder PATH_TO_MY_DATA
```

It seems that select_agents function receives the 'path' (relative to the local data folder) to .zarr file and then it tries to find the 'path' in the local data folder.

I think it's ok just passing the argument 'input_folder' to ChunkedStateDataset constructor and I removed LocalDataManeger from select_agents module.

It solved the error in the visualization example.

Please check my update.