### PR TITLE
Lberg/add deps version

### DIFF
--- a/l5kit/run_tests.sh
+++ b/l5kit/run_tests.sh
@@ -22,7 +22,7 @@ lint() {
 
 isort() {
   echo "import sorting.."
-  ${PYTHON_EXECUTABLE} -m isort l5kit --check-only --recursive
+  ${PYTHON_EXECUTABLE} -m isort l5kit --check-only
 }
 
 types() {

--- a/l5kit/setup.py
+++ b/l5kit/setup.py
@@ -32,7 +32,7 @@ setup(
     ],
     extras_require={
         "dev": ["pytest==5.4.3", "mypy==0.782", "setuptools", "twine", "wheel", "pytest-cov==2.10.0", "flake8==3.8.3",
-                "black==19.10b0", "isort==5.0.3", "Sphinx==3.1.1", "sphinx-rtd-theme==0.5.0", "recommonmark==0.6.0",
+                "black==19.10b0", "isort==5.0.4", "Sphinx==3.1.1", "sphinx-rtd-theme==0.5.0", "recommonmark==0.6.0",
                 "pre-commit==2.5.1"]
     },
     packages=find_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests"]),

--- a/l5kit/setup.py
+++ b/l5kit/setup.py
@@ -16,7 +16,7 @@ setup(
         "matplotlib",
         "numpy",
         "opencv-contrib-python-headless",
-        "protobuf",
+        "protobuf==3.12.2",
         "pymap3d",
         "scipy",
         "setuptools",
@@ -31,8 +31,9 @@ setup(
         "ipywidgets"
     ],
     extras_require={
-        "dev": ["pytest", "mypy", "setuptools", "twine", "wheel", "pytest-cov", "flake8", "black", "isort",
-                "Sphinx", "sphinx-rtd-theme", "recommonmark", "pre-commit"]
+        "dev": ["pytest==5.4.3", "mypy==0.7.80", "setuptools", "twine", "wheel", "pytest-cov==2.10.0", "flake8==3.8.3",
+                "black==19.10b0", "isort==5.0.3", "Sphinx==3.1.1", "sphinx-rtd-theme==0.5.0", "recommonmark==0.6.0",
+                "pre-commit==2.5.1"]
     },
     packages=find_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests"]),
     classifiers=[

--- a/l5kit/setup.py
+++ b/l5kit/setup.py
@@ -31,7 +31,7 @@ setup(
         "ipywidgets"
     ],
     extras_require={
-        "dev": ["pytest==5.4.3", "mypy==0.7.80", "setuptools", "twine", "wheel", "pytest-cov==2.10.0", "flake8==3.8.3",
+        "dev": ["pytest==5.4.3", "mypy==0.782", "setuptools", "twine", "wheel", "pytest-cov==2.10.0", "flake8==3.8.3",
                 "black==19.10b0", "isort==5.0.3", "Sphinx==3.1.1", "sphinx-rtd-theme==0.5.0", "recommonmark==0.6.0",
                 "pre-commit==2.5.1"]
     },


### PR DESCRIPTION
Add version to some deps (especially dev). This should ensure we don't have weird behaviours in CI (like `isort` dropping `--recursive` from 5.0 )