### PR TITLE
Fix a rare crash in prediction script

### DIFF
--- a/examples/agent_motion_prediction/agent_motion_prediction.ipynb
+++ b/examples/agent_motion_prediction/agent_motion_prediction.ipynb
@@ -210,11 +210,11 @@
     "    losses_eval.append(loss.item())\n",
     "    progress_bar.set_description(f\"Running EVAL, loss: {loss.item()} loss(avg): {np.mean(losses_eval)}\")\n",
     "\n",
-    "    future_coords_offsets_pd.append(ouputs.reshape(len(ouputs), -1, 2).cpu().numpy())\n",
-    "    future_coords_offsets_gt.append(data[\"target_positions\"].reshape(len(ouputs), -1, 2).cpu().numpy())\n",
+    "    future_coords_offsets_pd.append(ouputs.reshape(len(ouputs), -1, 2).cpu().numpy().copy())\n",
+    "    future_coords_offsets_gt.append(data[\"target_positions\"].reshape(len(ouputs), -1, 2).cpu().numpy().copy())\n",
     "\n",
-    "    timestamps.append(data[\"timestamp\"].numpy())\n",
-    "    agent_ids.append(data[\"track_id\"].numpy())\n",
+    "    timestamps.append(data[\"timestamp\"].numpy().copy())\n",
+    "    agent_ids.append(data[\"track_id\"].numpy().copy())\n",
     "    "
    ]
   },


### PR DESCRIPTION
Add a copy for elements returned from dataset when they are appended to
a list. This causes a subtle crash on some linux machines when
num_workers > 0 both with dicts and arrays as return values from
`__getitem__`