### PR TITLE
Lberg/move pose ecef matrix

### DIFF
--- a/examples/agent_motion_prediction/agent_motion_config.yaml
+++ b/examples/agent_motion_prediction/agent_motion_config.yaml
@@ -34,6 +34,7 @@ raster_params:
   # the keys are relative to the dataset environment variable
   satellite_map_key: "aerial_map/aerial_map.png"
   semantic_map_key: "semantic_map/semantic_map.pb"
+  dataset_meta_key: "meta.json"
 
   # e.g. 0.0 include every obstacle, 0.5 show those obstacles with >0.5 probability of being
   # one of the classes we care about (cars, bikes, peds, etc.), >=1.0 filter all other agents.

--- a/examples/visualisation/visualisation_config.yaml
+++ b/examples/visualisation/visualisation_config.yaml
@@ -34,6 +34,7 @@ raster_params:
   # the keys are relative to the dataset environment variable
   satellite_map_key: "aerial_map/aerial_map.png"
   semantic_map_key: "semantic_map/semantic_map.pb"
+  dataset_meta_key: "meta.json"
 
   # e.g. 0.0 include every obstacle, 0.5 show those obstacles with >0.5 probability of being
   # one of the classes we care about (cars, bikes, peds, etc.), >=1.0 filter all other agents.

--- a/l5kit/l5kit/data/__init__.py
+++ b/l5kit/l5kit/data/__init__.py
@@ -2,7 +2,7 @@ from .combine import get_combined_scenes
 from .filter import filter_agents_by_frame, filter_agents_by_frames, filter_agents_by_labels, get_agent_by_track_id
 from .labels import LABEL_TO_INDEX, LABELS
 from .local_data_manager import DataManager, LocalDataManager
-from .map import load_pose_to_ecef, load_semantic_map
+from .map import load_semantic_map
 from .zarr_dataset import AGENT_DTYPE, FRAME_DTYPE, SCENE_DTYPE, ChunkedStateDataset
 
 __all__ = [
@@ -20,5 +20,4 @@ __all__ = [
     "get_agent_by_track_id",
     "filter_agents_by_frames",
     "load_semantic_map",
-    "load_pose_to_ecef",
 ]

--- a/l5kit/l5kit/data/map.py
+++ b/l5kit/l5kit/data/map.py
@@ -6,25 +6,6 @@ import pymap3d as pm
 from .proto.road_network_pb2 import GeoFrame, Lane, MapFragment, TrafficControlElement
 
 
-# TODO read from elsewhere, it should be read from dataset metadata or elsewhere. Not hard-coded
-def load_pose_to_ecef() -> np.ndarray:
-    """Loads the pose to ECEF transformation matrix.
-
-    Returns:
-        np.ndarray: 4x4 transformation matrix of dtype ``np.float64``.
-    """
-
-    return np.array(
-        [
-            [8.46617444e-01, 3.23463078e-01, -4.22623402e-01, -2.69876744e06],
-            [-5.32201938e-01, 5.14559352e-01, -6.72301845e-01, -4.29315158e06],
-            [-3.05311332e-16, 7.94103464e-01, 6.07782600e-01, 3.85516476e06],
-            [0.00000000e00, 0.00000000e00, 0.00000000e00, 1.00000000e00],
-        ],
-        dtype=np.float64,
-    )
-
-
 def load_semantic_map(semantic_map_path: str) -> dict:
     """Loads and does preprocessing of given semantic map in binary proto format.
 

--- a/l5kit/l5kit/rasterization/rasterizer_builder.py
+++ b/l5kit/l5kit/rasterization/rasterizer_builder.py
@@ -1,5 +1,6 @@
 import json
 import os
+from sys import exit
 from typing import Tuple, cast
 
 import cv2

--- a/l5kit/l5kit/rasterization/rasterizer_builder.py
+++ b/l5kit/l5kit/rasterization/rasterizer_builder.py
@@ -1,6 +1,5 @@
 import json
 import os
-from sys import exit
 from typing import Tuple, cast
 
 import cv2
@@ -82,12 +81,11 @@ def build_rasterizer(cfg: dict, data_manager: DataManager) -> Rasterizer:
         try:
             pose_to_ecef = np.array(_load_metadata(data_meta_key, data_manager)["pose_to_ecef"], dtype=np.float64)
         except FileNotFoundError:  # TODO remove in v1.0.5
-            print(
-                "!!dataset metafile not found!! this check has been introduced in l5kit v1.0.4"
-                "The file is already available in the public dataset folder, please download it."
+            raise FileNotFoundError(
+                "!!dataset metafile not found!! this check has been introduced in l5kit v1.0.4\n"
+                "The file is already available in the public dataset folder, please download it.\n"
                 "This message will be removed in l5kit v1.0.5"
             )
-            exit()
 
         map_to_sat = np.matmul(ecef_to_sat, pose_to_ecef)
         return SatBoxRasterizer(
@@ -99,12 +97,11 @@ def build_rasterizer(cfg: dict, data_manager: DataManager) -> Rasterizer:
         try:
             pose_to_ecef = np.array(_load_metadata(data_meta_key, data_manager)["pose_to_ecef"], dtype=np.float64)
         except FileNotFoundError:  # TODO remove in v1.0.5
-            print(
-                "!!dataset metafile not found!! this check has been introduced in l5kit v1.0.4"
-                "The file is already available in the public dataset folder, please download it."
+            raise FileNotFoundError(
+                "!!dataset metafile not found!! this check has been introduced in l5kit v1.0.4\n"
+                "The file is already available in the public dataset folder, please download it.\n"
                 "This message will be removed in l5kit v1.0.5"
             )
-            exit()
 
         return SemBoxRasterizer(
             raster_size,

--- a/l5kit/l5kit/rasterization/rasterizer_builder.py
+++ b/l5kit/l5kit/rasterization/rasterizer_builder.py
@@ -97,7 +97,7 @@ def build_rasterizer(cfg: dict, data_manager: DataManager) -> Rasterizer:
         semantic_map = load_semantic_map(semantic_map_filepath)
         try:
             pose_to_ecef = np.array(_load_metadata(data_meta_key, data_manager)["pose_to_ecef"], dtype=np.float64)
-        except FileNotFoundError:
+        except FileNotFoundError:  # TODO remove in v1.0.5
             print(
                 "!!dataset metafile not found!! this check has been introduced in l5kit v1.0.4"
                 "The file is already available in the public dataset folder, please download it."

--- a/l5kit/l5kit/rasterization/rasterizer_builder.py
+++ b/l5kit/l5kit/rasterization/rasterizer_builder.py
@@ -78,7 +78,15 @@ def build_rasterizer(cfg: dict, data_manager: DataManager) -> Rasterizer:
 
         sat_meta_key = os.path.splitext(sat_image_key)[0] + ".json"
         ecef_to_sat = np.array(_load_metadata(sat_meta_key, data_manager)["ecef_to_image"], dtype=np.float64)
-        pose_to_ecef = np.array(_load_metadata(data_meta_key, data_manager)["pose_to_ecef"], dtype=np.float64)
+        try:
+            pose_to_ecef = np.array(_load_metadata(data_meta_key, data_manager)["pose_to_ecef"], dtype=np.float64)
+        except FileNotFoundError:  # TODO remove in v1.0.5
+            print(
+                "!!dataset metafile not found!! this check has been introduced in l5kit v1.0.4"
+                "The file is already available in the public dataset folder, please download it."
+                "This message will be removed in l5kit v1.0.5"
+            )
+            exit()
 
         map_to_sat = np.matmul(ecef_to_sat, pose_to_ecef)
         return SatBoxRasterizer(
@@ -87,7 +95,15 @@ def build_rasterizer(cfg: dict, data_manager: DataManager) -> Rasterizer:
     elif map_type == "py_semantic":
         semantic_map_filepath = data_manager.require(raster_cfg["semantic_map_key"])
         semantic_map = load_semantic_map(semantic_map_filepath)
-        pose_to_ecef = np.array(_load_metadata(data_meta_key, data_manager)["pose_to_ecef"], dtype=np.float64)
+        try:
+            pose_to_ecef = np.array(_load_metadata(data_meta_key, data_manager)["pose_to_ecef"], dtype=np.float64)
+        except FileNotFoundError:
+            print(
+                "!!dataset metafile not found!! this check has been introduced in l5kit v1.0.4"
+                "The file is already available in the public dataset folder, please download it."
+                "This message will be removed in l5kit v1.0.5"
+            )
+            exit()
 
         return SemBoxRasterizer(
             raster_size,

--- a/l5kit/l5kit/rasterization/rasterizer_builder.py
+++ b/l5kit/l5kit/rasterization/rasterizer_builder.py
@@ -74,12 +74,15 @@ def build_rasterizer(cfg: dict, data_manager: DataManager) -> Rasterizer:
 
     if map_type == "py_satellite":
         sat_image_key = raster_cfg["satellite_map_key"]
-        sat_image = _load_satellite_map(sat_image_key, data_manager)
-
         sat_meta_key = os.path.splitext(sat_image_key)[0] + ".json"
-        ecef_to_sat = np.array(_load_metadata(sat_meta_key, data_manager)["ecef_to_image"], dtype=np.float64)
+
+        sat_image = _load_satellite_map(sat_image_key, data_manager)
+        sat_meta = _load_metadata(sat_meta_key, data_manager)
+        ecef_to_sat = np.array(sat_meta["ecef_to_image"], dtype=np.float64)
+
         try:
-            pose_to_ecef = np.array(_load_metadata(dataset_meta_key, data_manager)["pose_to_ecef"], dtype=np.float64)
+            dataset_meta = _load_metadata(dataset_meta_key, data_manager)
+            pose_to_ecef = np.array(dataset_meta["pose_to_ecef"], dtype=np.float64)
         except (KeyError, FileNotFoundError):  # TODO remove when new dataset version is available
             print(
                 "!!dataset metafile not found!! the hard-coded matrix will be loaded.\n"
@@ -103,7 +106,8 @@ def build_rasterizer(cfg: dict, data_manager: DataManager) -> Rasterizer:
         semantic_map_filepath = data_manager.require(raster_cfg["semantic_map_key"])
         semantic_map = load_semantic_map(semantic_map_filepath)
         try:
-            pose_to_ecef = np.array(_load_metadata(dataset_meta_key, data_manager)["pose_to_ecef"], dtype=np.float64)
+            dataset_meta = _load_metadata(dataset_meta_key, data_manager)
+            pose_to_ecef = np.array(dataset_meta["pose_to_ecef"], dtype=np.float64)
         except (KeyError, FileNotFoundError):  # TODO remove when new dataset version is available
             print(
                 "!!dataset metafile not found!! the hard-coded matrix will be loaded.\n"

--- a/l5kit/l5kit/rasterization/rasterizer_builder.py
+++ b/l5kit/l5kit/rasterization/rasterizer_builder.py
@@ -22,8 +22,8 @@ def _load_metadata(meta_key: str, data_manager: DataManager) -> dict:
     Returns:
         dict: metadata as a dict
     """
-    image_metadata_path = data_manager.require(meta_key)
-    with open(image_metadata_path, "r") as f:
+    metadata_path = data_manager.require(meta_key)
+    with open(metadata_path, "r") as f:
         metadata: dict = json.load(f)
     return metadata
 
@@ -64,7 +64,7 @@ def build_rasterizer(cfg: dict, data_manager: DataManager) -> Rasterizer:
     """
     raster_cfg = cfg["raster_params"]
     map_type = raster_cfg["map_type"]
-    data_meta_key = raster_cfg["dataset_meta_key"]
+    dataset_meta_key = raster_cfg["dataset_meta_key"]
 
     raster_size: Tuple[int, int] = cast(Tuple[int, int], tuple(raster_cfg["raster_size"]))
     pixel_size = np.array(raster_cfg["pixel_size"])
@@ -79,7 +79,7 @@ def build_rasterizer(cfg: dict, data_manager: DataManager) -> Rasterizer:
         sat_meta_key = os.path.splitext(sat_image_key)[0] + ".json"
         ecef_to_sat = np.array(_load_metadata(sat_meta_key, data_manager)["ecef_to_image"], dtype=np.float64)
         try:
-            pose_to_ecef = np.array(_load_metadata(data_meta_key, data_manager)["pose_to_ecef"], dtype=np.float64)
+            pose_to_ecef = np.array(_load_metadata(dataset_meta_key, data_manager)["pose_to_ecef"], dtype=np.float64)
         except (KeyError, FileNotFoundError):  # TODO remove when new dataset version is available
             print(
                 "!!dataset metafile not found!! the hard-coded matrix will be loaded.\n"
@@ -103,7 +103,7 @@ def build_rasterizer(cfg: dict, data_manager: DataManager) -> Rasterizer:
         semantic_map_filepath = data_manager.require(raster_cfg["semantic_map_key"])
         semantic_map = load_semantic_map(semantic_map_filepath)
         try:
-            pose_to_ecef = np.array(_load_metadata(data_meta_key, data_manager)["pose_to_ecef"], dtype=np.float64)
+            pose_to_ecef = np.array(_load_metadata(dataset_meta_key, data_manager)["pose_to_ecef"], dtype=np.float64)
         except (KeyError, FileNotFoundError):  # TODO remove when new dataset version is available
             print(
                 "!!dataset metafile not found!! the hard-coded matrix will be loaded.\n"

--- a/l5kit/l5kit/rasterization/rasterizer_builder.py
+++ b/l5kit/l5kit/rasterization/rasterizer_builder.py
@@ -5,39 +5,46 @@ from typing import Tuple, cast
 import cv2
 import numpy as np
 
-from ..data import DataManager, load_pose_to_ecef, load_semantic_map
+from ..data import DataManager, load_semantic_map
 from .rasterizer import Rasterizer
 from .sat_box_rasterizer import SatBoxRasterizer
 from .sem_box_rasterizer import SemBoxRasterizer
 
 
-def _load_image_and_metadata(image_key: str, data_manager: DataManager) -> Tuple[np.ndarray, dict]:
-    """Loads image from given key and its meatadata. The metadata file should be a file with the same key except for
-    having a .json extension instead.
+def _load_metadata(meta_key: str, data_manager: DataManager) -> dict:
+    """
+    Load a json metadata file
+
+    Args:
+        meta_key (str): relative key to the metadata
+        data_manager (DataManager): DataManager used for requiring files
+
+    Returns:
+        dict: metadata as a dict
+    """
+    image_metadata_path = data_manager.require(meta_key)
+    with open(image_metadata_path, "r") as f:
+        metadata: dict = json.load(f)
+    return metadata
+
+
+def _load_satellite_map(image_key: str, data_manager: DataManager) -> np.ndarray:
+    """Loads image from given key.
 
     Args:
         image_key (str): key to the image (e.g. ``maps/my_satellite_image.png``)
         data_manager (DataManager): DataManager used for requiring files
 
-    Raises:
-        Exception: Image or metadata is missing or invalid
-
     Returns:
-        Tuple[np.ndarray, dict]: Image and metadata
+        np.ndarry: Image
     """
 
-    image_metadata_key = os.path.splitext(image_key)[0] + ".json"
     image_path = data_manager.require(image_key)
-    image_metadata_path = data_manager.require(image_metadata_key)
-
     image = cv2.imread(image_path)[..., ::-1]  # BGR->RGB
     if image is None:
         raise Exception(f"Failed to load image from {image_path}")
 
-    with open(image_metadata_path, "r") as f:
-        metadata = json.load(f)
-
-    return image, metadata
+    return image
 
 
 def build_rasterizer(cfg: dict, data_manager: DataManager) -> Rasterizer:
@@ -57,6 +64,7 @@ def build_rasterizer(cfg: dict, data_manager: DataManager) -> Rasterizer:
     """
     raster_cfg = cfg["raster_params"]
     map_type = raster_cfg["map_type"]
+    data_meta_key = raster_cfg["dataset_meta_key"]
 
     raster_size: Tuple[int, int] = cast(Tuple[int, int], tuple(raster_cfg["raster_size"]))
     pixel_size = np.array(raster_cfg["pixel_size"])
@@ -65,9 +73,12 @@ def build_rasterizer(cfg: dict, data_manager: DataManager) -> Rasterizer:
     history_num_frames = cfg["model_params"]["history_num_frames"]
 
     if map_type in ["py_satellite", "satellite_rgb"]:
-        sat_image, meta = _load_image_and_metadata(raster_cfg["satellite_map_key"], data_manager)
-        ecef_to_sat = np.array(meta["ecef_to_image"], dtype=np.float64)
-        pose_to_ecef = load_pose_to_ecef()
+        sat_image_key = raster_cfg["satellite_map_key"]
+        sat_image = _load_satellite_map(sat_image_key, data_manager)
+
+        sat_meta_key = os.path.splitext(sat_image_key)[0] + ".json"
+        ecef_to_sat = np.array(_load_metadata(sat_meta_key, data_manager)["ecef_to_image"], dtype=np.float64)
+        pose_to_ecef = np.array(_load_metadata(data_meta_key, data_manager)["pose_to_ecef"], dtype=np.float64)
 
         map_to_sat = np.matmul(ecef_to_sat, pose_to_ecef)
         return SatBoxRasterizer(
@@ -76,7 +87,7 @@ def build_rasterizer(cfg: dict, data_manager: DataManager) -> Rasterizer:
     elif map_type == "py_semantic":
         semantic_map_filepath = data_manager.require(raster_cfg["semantic_map_key"])
         semantic_map = load_semantic_map(semantic_map_filepath)
-        pose_to_ecef = load_pose_to_ecef()
+        pose_to_ecef = np.array(_load_metadata(data_meta_key, data_manager)["pose_to_ecef"], dtype=np.float64)
 
         return SemBoxRasterizer(
             raster_size,

--- a/l5kit/l5kit/rasterization/rasterizer_builder.py
+++ b/l5kit/l5kit/rasterization/rasterizer_builder.py
@@ -72,7 +72,7 @@ def build_rasterizer(cfg: dict, data_manager: DataManager) -> Rasterizer:
     filter_agents_threshold = raster_cfg["filter_agents_threshold"]
     history_num_frames = cfg["model_params"]["history_num_frames"]
 
-    if map_type in ["py_satellite", "satellite_rgb"]:
+    if map_type == "py_satellite":
         sat_image_key = raster_cfg["satellite_map_key"]
         sat_image = _load_satellite_map(sat_image_key, data_manager)
 

--- a/l5kit/l5kit/rasterization/rasterizer_builder.py
+++ b/l5kit/l5kit/rasterization/rasterizer_builder.py
@@ -80,11 +80,19 @@ def build_rasterizer(cfg: dict, data_manager: DataManager) -> Rasterizer:
         ecef_to_sat = np.array(_load_metadata(sat_meta_key, data_manager)["ecef_to_image"], dtype=np.float64)
         try:
             pose_to_ecef = np.array(_load_metadata(data_meta_key, data_manager)["pose_to_ecef"], dtype=np.float64)
-        except FileNotFoundError:  # TODO remove in v1.0.5
-            raise FileNotFoundError(
-                "!!dataset metafile not found!! this check has been introduced in l5kit v1.0.4\n"
-                "The file is already available in the public dataset folder, please download it.\n"
-                "This message will be removed in l5kit v1.0.5"
+        except (KeyError, FileNotFoundError):  # TODO remove when new dataset version is available
+            print(
+                "!!dataset metafile not found!! the hard-coded matrix will be loaded.\n"
+                "This will be deprecated in future releases"
+            )
+            pose_to_ecef = np.asarray(
+                [
+                    [8.46617444e-01, 3.23463078e-01, -4.22623402e-01, -2.69876744e06],
+                    [-5.32201938e-01, 5.14559352e-01, -6.72301845e-01, -4.29315158e06],
+                    [-3.05311332e-16, 7.94103464e-01, 6.07782600e-01, 3.85516476e06],
+                    [0.00000000e00, 0.00000000e00, 0.00000000e00, 1.00000000e00],
+                ],
+                dtype=np.float64,
             )
 
         map_to_sat = np.matmul(ecef_to_sat, pose_to_ecef)
@@ -96,11 +104,19 @@ def build_rasterizer(cfg: dict, data_manager: DataManager) -> Rasterizer:
         semantic_map = load_semantic_map(semantic_map_filepath)
         try:
             pose_to_ecef = np.array(_load_metadata(data_meta_key, data_manager)["pose_to_ecef"], dtype=np.float64)
-        except FileNotFoundError:  # TODO remove in v1.0.5
-            raise FileNotFoundError(
-                "!!dataset metafile not found!! this check has been introduced in l5kit v1.0.4\n"
-                "The file is already available in the public dataset folder, please download it.\n"
-                "This message will be removed in l5kit v1.0.5"
+        except (KeyError, FileNotFoundError):  # TODO remove when new dataset version is available
+            print(
+                "!!dataset metafile not found!! the hard-coded matrix will be loaded.\n"
+                "This will be deprecated in future releases"
+            )
+            pose_to_ecef = np.asarray(
+                [
+                    [8.46617444e-01, 3.23463078e-01, -4.22623402e-01, -2.69876744e06],
+                    [-5.32201938e-01, 5.14559352e-01, -6.72301845e-01, -4.29315158e06],
+                    [-3.05311332e-16, 7.94103464e-01, 6.07782600e-01, 3.85516476e06],
+                    [0.00000000e00, 0.00000000e00, 0.00000000e00, 1.00000000e00],
+                ],
+                dtype=np.float64,
             )
 
         return SemBoxRasterizer(

--- a/l5kit/l5kit/tests/dataset/dataset_test.py
+++ b/l5kit/l5kit/tests/dataset/dataset_test.py
@@ -5,7 +5,7 @@ import pytest
 from torch.utils.data import DataLoader, Dataset, Subset
 
 from l5kit.configs import load_config_data
-from l5kit.data import ChunkedStateDataset, load_pose_to_ecef
+from l5kit.data import ChunkedStateDataset
 from l5kit.dataset import AgentDataset, EgoDataset
 from l5kit.rasterization import (
     BoxRasterizer,
@@ -32,9 +32,10 @@ def get_rasterizer(rast_name: str, cfg: dict) -> Rasterizer:
     map_to_sat = np.block(
         [[np.eye(3) / 100, np.asarray([[1000], [1000], [1]])], [np.asarray([[0, 0, 0, 1]])]]
     )  # just a translation and scale
+    pose_to_ecef = np.eye(4)
     map_im = np.zeros((10000, 10000, 3), dtype=np.uint8)
+
     # sem params
-    pose_to_ecef = load_pose_to_ecef()
     semantic_map = {
         "lanes": [],
         "lat": 37.44,

--- a/l5kit/l5kit/tests/rasterization/rasterizer_e2e_test.py
+++ b/l5kit/l5kit/tests/rasterization/rasterizer_e2e_test.py
@@ -59,8 +59,8 @@ def setup_rasterizer_artifacts_and_config(temp_folder: str, cfg: dict) -> None:
     with open(os.path.join(temp_folder, sat_im_metadata_filename), "w") as ft:
         json.dump(sat_im_transform_json_content, ft)
 
-    dataset_metadata_filename = "dataset_meta.json"
-    cfg["raster_params"]["dataset_meta_key"] = dataset_metadata_filename
+    dataset_meta_key = "dataset_meta.json"
+    cfg["raster_params"]["dataset_meta_key"] = dataset_meta_key
 
     pose_ecef_transform_json_content = {
         "pose_to_ecef": [
@@ -70,7 +70,7 @@ def setup_rasterizer_artifacts_and_config(temp_folder: str, cfg: dict) -> None:
             [0.00000000e00, 0.00000000e00, 0.00000000e00, 1.00000000e00],
         ]
     }
-    with open(os.path.join(temp_folder, dataset_metadata_filename), "w") as ft:
+    with open(os.path.join(temp_folder, dataset_meta_key), "w") as ft:
         json.dump(pose_ecef_transform_json_content, ft)
 
 

--- a/l5kit/l5kit/tests/rasterization/rasterizer_e2e_test.py
+++ b/l5kit/l5kit/tests/rasterization/rasterizer_e2e_test.py
@@ -59,6 +59,20 @@ def setup_rasterizer_artifacts_and_config(temp_folder: str, cfg: dict) -> None:
     with open(os.path.join(temp_folder, sat_im_metadata_filename), "w") as ft:
         json.dump(sat_im_transform_json_content, ft)
 
+    dataset_metadata_filename = "dataset_meta.json"
+    cfg["raster_params"]["dataset_meta_key"] = dataset_metadata_filename
+
+    pose_ecef_transform_json_content = {
+        "pose_to_ecef": [
+            [8.46617444e-01, 3.23463078e-01, -4.22623402e-01, -2.69876744e06],
+            [-5.32201938e-01, 5.14559352e-01, -6.72301845e-01, -4.29315158e06],
+            [-3.05311332e-16, 7.94103464e-01, 6.07782600e-01, 3.85516476e06],
+            [0.00000000e00, 0.00000000e00, 0.00000000e00, 1.00000000e00],
+        ]
+    }
+    with open(os.path.join(temp_folder, dataset_metadata_filename), "w") as ft:
+        json.dump(pose_ecef_transform_json_content, ft)
+
 
 def check_rasterizer(cfg: dict, rasterizer: Rasterizer, dataset: ChunkedStateDataset) -> None:
     frames = dataset.frames[:]  # Load all frames into memory

--- a/l5kit/l5kit/tests/rasterization/rasterizer_e2e_test.py
+++ b/l5kit/l5kit/tests/rasterization/rasterizer_e2e_test.py
@@ -59,7 +59,7 @@ def setup_rasterizer_artifacts_and_config(temp_folder: str, cfg: dict) -> None:
     with open(os.path.join(temp_folder, sat_im_metadata_filename), "w") as ft:
         json.dump(sat_im_transform_json_content, ft)
 
-    dataset_meta_key = "dataset_meta.json"
+    dataset_meta_key = "meta.json"
     cfg["raster_params"]["dataset_meta_key"] = dataset_meta_key
 
     pose_ecef_transform_json_content = {


### PR DESCRIPTION
This PR remove the hardcoded pose_to_ecef matrix (except for tests, but that's going to be part of major refactor later on). The matrix will be stored in a `json` metafile for the dataset. We fall back to hardcoded right now, that will be removed in the future.

- [x] add informative error
- [x] test notebooks
- [x] fall back to hard-coded for now 

the file will be uploaded in future dataset releases