### PR TITLE
get_combined_scenes is now not default

### DIFF
--- a/l5kit/l5kit/dataset/dataloader_builder.py
+++ b/l5kit/l5kit/dataset/dataloader_builder.py
@@ -15,7 +15,7 @@ def build_dataloader(
     dataset_class: Callable,
     rasterizer: Rasterizer,
     perturbation: Optional[Perturbation] = None,
-    combine_scene: bool = False,
+    combine_scenes: bool = False,
 ) -> DataLoader:
     """
     Function to build a dataloader from a dataset of dataset_class. Note we have to pass rasterizer and
@@ -28,7 +28,7 @@ def build_dataloader(
         dataset_class (Callable): a class object (EgoDataset or AgentDataset currently) to build the dataset
         rasterizer (Rasterizer): the rasterizer for the dataset
         perturbation (Optional[Perturbation]): an optional perturbation object
-        combine_scene (float): if to combine scenes that follow up each other perfectly
+        combine_scenes (bool): if to combine scenes that follow up each other perfectly
 
     Returns:
         DataLoader: pytorch Dataloader object built with Concat and Sub datasets
@@ -40,7 +40,7 @@ def build_dataloader(
         zarr_dataset_path = data_manager.require(key=dataset_param["key"])
         zarr_dataset = ChunkedStateDataset(path=zarr_dataset_path)
         zarr_dataset.open()
-        if combine_scene:  # possible future deprecation
+        if combine_scenes:  # possible future deprecation
             zarr_dataset.scenes = get_combined_scenes(zarr_dataset.scenes)
 
         #  Let's load the zarr dataset with our dataset.

--- a/l5kit/l5kit/dataset/dataloader_builder.py
+++ b/l5kit/l5kit/dataset/dataloader_builder.py
@@ -15,6 +15,7 @@ def build_dataloader(
     dataset_class: Callable,
     rasterizer: Rasterizer,
     perturbation: Optional[Perturbation] = None,
+    combine_scene: bool = False,
 ) -> DataLoader:
     """
     Function to build a dataloader from a dataset of dataset_class. Note we have to pass rasterizer and
@@ -27,6 +28,7 @@ def build_dataloader(
         dataset_class (Callable): a class object (EgoDataset or AgentDataset currently) to build the dataset
         rasterizer (Rasterizer): the rasterizer for the dataset
         perturbation (Optional[Perturbation]): an optional perturbation object
+        combine_scene (float): if to combine scenes that follow up each other perfectly
 
     Returns:
         DataLoader: pytorch Dataloader object built with Concat and Sub datasets
@@ -38,7 +40,8 @@ def build_dataloader(
         zarr_dataset_path = data_manager.require(key=dataset_param["key"])
         zarr_dataset = ChunkedStateDataset(path=zarr_dataset_path)
         zarr_dataset.open()
-        zarr_dataset.scenes = get_combined_scenes(zarr_dataset.scenes)
+        if combine_scene:  # possible future deprecation
+            zarr_dataset.scenes = get_combined_scenes(zarr_dataset.scenes)
 
         #  Let's load the zarr dataset with our dataset.
         dataset = dataset_class(cfg, zarr_dataset, rasterizer, perturbation=perturbation)


### PR DESCRIPTION
`get_combined_scenes` is now not called automatically in `dataloader_builder`. This fix an issue with the first run of AgentDataset when the mask is computed because:
- the ChunkedStateDataset is created and scenes aggregated
- the object is stored in `self.datataset` for the `AgentDataset` by super call. This also set `cumulative_sizes` using scenes (aggregated)
- mask is computed (require re-opening the dataset which is performed without calling `get_combined_scenes`) and **root updated** (frames, scenes and agents reloaded)
- `cumulative_sizes_agents` is set

Clearly, the two cumulative sizes don't match. If the script is run again, `cumulative_sizes_agents` is created using the aggregated scenes instead and everything works.

Note: this was having an impact on the `agents_mask` (not a dramatic one actually)