### PR TITLE
replace path with dataset for select_agents, avoid calling open again in AgentDataset

### DIFF
--- a/l5kit/l5kit/dataset/agent.py
+++ b/l5kit/l5kit/dataset/agent.py
@@ -1,7 +1,9 @@
 import bisect
+from pathlib import Path
 from typing import Optional
 
 import numpy as np
+from zarr import convenience
 
 from ..data import ChunkedStateDataset
 from ..kinematic import Perturbation
@@ -61,8 +63,8 @@ class AgentDataset(EgoDataset):
                 th_movement=TH_MOVEMENT,
                 th_distance_av=TH_DISTANCE_AV,
             )
-            self.dataset.open()  # ensure root is updated, reload all arrays TODO lberg: avoid reload
-            agents_mask = self.dataset.root[f"agents_mask/{group_name}"]
+            array_path = Path(self.dataset.path) / f"agents_mask/{group_name}"
+            agents_mask = convenience.load(str(array_path))  # note (lberg): this doesn't update root
 
         return agents_mask
 

--- a/l5kit/l5kit/dataset/agent.py
+++ b/l5kit/l5kit/dataset/agent.py
@@ -60,7 +60,6 @@ class AgentDataset(EgoDataset):
                 th_extent_ratio=TH_EXTENT_RATIO,
                 th_movement=TH_MOVEMENT,
                 th_distance_av=TH_DISTANCE_AV,
-                num_workers=8,  # TODO maybe set in env var?
             )
             self.dataset.open()  # ensure root is updated, reload all arrays TODO lberg: avoid reload
             agents_mask = self.dataset.root[f"agents_mask/{group_name}"]

--- a/l5kit/l5kit/dataset/agent.py
+++ b/l5kit/l5kit/dataset/agent.py
@@ -52,7 +52,7 @@ class AgentDataset(EgoDataset):
                 "Mask will now be generated for these parameters."
             )
             select_agents(
-                self.dataset.path,
+                self.dataset,
                 agent_prob,
                 history_num_frames,
                 future_num_frames,
@@ -60,9 +60,9 @@ class AgentDataset(EgoDataset):
                 th_extent_ratio=TH_EXTENT_RATIO,
                 th_movement=TH_MOVEMENT,
                 th_distance_av=TH_DISTANCE_AV,
-                num_workers=8,
-            )  # TODO maybe set in env var?
-            self.dataset.open()  # ensure root is updated
+                num_workers=8,  # TODO maybe set in env var?
+            )
+            self.dataset.open()  # ensure root is updated, reload all arrays TODO lberg: avoid reload
             agents_mask = self.dataset.root[f"agents_mask/{group_name}"]
 
         return agents_mask

--- a/l5kit/l5kit/dataset/select_agents.py
+++ b/l5kit/l5kit/dataset/select_agents.py
@@ -3,7 +3,7 @@ import os
 import pprint
 from collections import Counter, defaultdict
 from functools import partial
-from multiprocessing import Pool
+from multiprocessing import Pool, cpu_count
 from pathlib import Path
 from typing import List, Tuple
 from uuid import uuid4
@@ -176,7 +176,6 @@ def select_agents(
     th_extent_ratio: float,
     th_movement: float,
     th_distance_av: float,
-    num_workers: int,
 ) -> None:
     """
     Filter agents from zarr INPUT_FOLDER according to multiple thresholds and store a boolean array of the same shape.
@@ -219,7 +218,7 @@ def select_agents(
 
     report: Counter = Counter()
     print("starting pool...")
-    with Pool(num_workers) as pool:
+    with Pool(cpu_count()) as pool:
         tasks = tqdm(enumerate(pool.imap_unordered(get_valid_agents_partial, frame_index_intervals)))
         for idx, (mask, count, agents_range) in tasks:
             report += count
@@ -250,7 +249,7 @@ def select_agents(
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument("--input_folder", nargs="+", type=str, required=True, help="zarr path")
+    parser.add_argument("--input_folders", nargs="+", type=str, required=True, help="zarr path")
     parser.add_argument("--th_agent_prob", type=float, default=0.5, help="perception threshold on agents of interest")
     parser.add_argument("--th_history_num_frames", type=int, default=0, help="frames in the past to be valid")
     parser.add_argument("--th_future_num_frames", type=int, default=12, help="frames in the future to be valid")
@@ -258,10 +257,9 @@ if __name__ == "__main__":
     parser.add_argument("--th_extent_ratio", type=float, default=TH_EXTENT_RATIO, help="max change in area allowed")
     parser.add_argument("--th_movement", type=float, default=TH_MOVEMENT, help="max movement in meters")
     parser.add_argument("--th_distance_av", type=float, default=TH_DISTANCE_AV, help="max distance from AV in meters")
-    parser.add_argument("-j", type=int, default=8, help="number of workers")
     args = parser.parse_args()
 
-    for input_folder in args.input_folder:
+    for input_folder in args.input_folders:
         zarr_dataset = ChunkedStateDataset(path=input_folder)
         zarr_dataset.open()
 
@@ -274,5 +272,4 @@ if __name__ == "__main__":
             args.th_extent_ratio,
             args.th_movement,
             args.th_distance_av,
-            args.j,
         )

--- a/l5kit/l5kit/dataset/select_agents.py
+++ b/l5kit/l5kit/dataset/select_agents.py
@@ -168,7 +168,7 @@ def get_valid_agents(
 
 
 def select_agents(
-    input_folder: str,
+    zarr_dataset: ChunkedStateDataset,
     th_agent_prob: float,
     th_history_num_frames: int,
     th_future_num_frames: int,
@@ -182,10 +182,6 @@ def select_agents(
     Filter agents from zarr INPUT_FOLDER according to multiple thresholds and store a boolean array of the same shape.
     """
     assert th_future_num_frames > 0
-
-    # ===== LOAD
-    zarr_dataset = ChunkedStateDataset(path=input_folder)
-    zarr_dataset.open()
 
     output_group = f"{th_history_num_frames}_{th_future_num_frames}_{th_agent_prob}"
     if "agents_mask" in zarr_dataset.root and f"agents_mask/{output_group}" in zarr_dataset.root:
@@ -246,9 +242,9 @@ def select_agents(
     }
     # print report
     pp = pprint.PrettyPrinter(indent=4)
-    print(f"start report for {input_folder}")
+    print(f"start report for {zarr_dataset.path}")
     pp.pprint({**agents_cfg, **report})
-    print(f"end report for {input_folder}")
+    print(f"end report for {zarr_dataset.path}")
     print("==============================")
 
 
@@ -266,8 +262,11 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     for input_folder in args.input_folder:
+        zarr_dataset = ChunkedStateDataset(path=input_folder)
+        zarr_dataset.open()
+
         select_agents(
-            input_folder,
+            zarr_dataset,
             args.th_agent_prob,
             args.th_history_num_frames,
             args.th_future_num_frames,


### PR DESCRIPTION
Replace first argument of select_agents (Path) with the `ChunkedStateDataset` itself. This avoid performing an `open()` call when `AgentDataset` builds the mask at runtime.

Note this is slightly related to #68. When both will be merged the behaviour will be back to normal (plus select_agents will be more accurate)