### PR TITLE
Lberg/fix arrow visualisation

### DIFF
--- a/l5kit/l5kit/visualization/utils.py
+++ b/l5kit/l5kit/visualization/utils.py
@@ -9,8 +9,9 @@ PREDICTED_POINTS_COLOR = (0, 255, 255)
 TARGET_POINTS_COLOR = (255, 0, 255)
 REFERENCE_TRAJECTORY_POINT_COLOR = (255, 255, 0)
 #  Arrows represent position + orientation.
-ARROW_LENGTH_IN_PIXELS = 4
+ARROW_LENGTH_IN_PIXELS = 2
 ARROW_THICKNESS_IN_PIXELS = 1
+ARROW_TIP_LENGTH = 1.8
 
 
 def draw_arrowed_line(on_image: np.ndarray, position: np.ndarray, yaw: float, rgb_color: Tuple[int, int, int]) -> None:
@@ -36,7 +37,7 @@ def draw_arrowed_line(on_image: np.ndarray, position: np.ndarray, yaw: float, rg
         tuple(end_pixel.astype(np.int32)),
         rgb_color,
         thickness=ARROW_THICKNESS_IN_PIXELS,
-        tipLength=1.8,
+        tipLength=ARROW_TIP_LENGTH,
     )
 
 

--- a/l5kit/l5kit/visualization/utils.py
+++ b/l5kit/l5kit/visualization/utils.py
@@ -11,7 +11,7 @@ REFERENCE_TRAJECTORY_POINT_COLOR = (255, 255, 0)
 #  Arrows represent position + orientation.
 ARROW_LENGTH_IN_PIXELS = 2
 ARROW_THICKNESS_IN_PIXELS = 1
-ARROW_TIP_LENGTH = 1.8
+ARROW_TIP_LENGTH_IN_PIXELS = 1.8
 
 
 def draw_arrowed_line(on_image: np.ndarray, position: np.ndarray, yaw: float, rgb_color: Tuple[int, int, int]) -> None:
@@ -37,7 +37,7 @@ def draw_arrowed_line(on_image: np.ndarray, position: np.ndarray, yaw: float, rg
         tuple(end_pixel.astype(np.int32)),
         rgb_color,
         thickness=ARROW_THICKNESS_IN_PIXELS,
-        tipLength=ARROW_TIP_LENGTH,
+        tipLength=ARROW_TIP_LENGTH_IN_PIXELS,
     )
 
 

--- a/l5kit/l5kit/visualization/utils.py
+++ b/l5kit/l5kit/visualization/utils.py
@@ -3,13 +3,13 @@ from typing import Tuple
 import cv2
 import numpy as np
 
-from l5kit.geometry import transform_points
+from l5kit.geometry import transform_point, transform_points
 
 PREDICTED_POINTS_COLOR = (0, 255, 255)
 TARGET_POINTS_COLOR = (255, 0, 255)
 REFERENCE_TRAJECTORY_POINT_COLOR = (255, 255, 0)
 #  Arrows represent position + orientation.
-ARROW_LENGTH_IN_PIXELS = 2
+ARROW_LENGTH_IN_PIXELS = 4
 ARROW_THICKNESS_IN_PIXELS = 1
 
 
@@ -25,11 +25,18 @@ def draw_arrowed_line(on_image: np.ndarray, position: np.ndarray, yaw: float, rg
     Returns: None
 
     """
-    position = np.array(position[:2])
-    start_pixel = np.int0(position)[:2]
-    end_pixel = np.int0(position + np.array([np.cos(yaw), -np.sin(yaw)]) * ARROW_LENGTH_IN_PIXELS)
+    start_pixel = np.array(position[:2])
+
+    rot = cv2.getRotationMatrix2D((0, 0), np.degrees(-yaw), 1.0)  # minus here because of cv2 rotations convention
+    end_pixel = start_pixel + transform_point(np.asarray([ARROW_LENGTH_IN_PIXELS, 0]), rot)
+
     cv2.arrowedLine(
-        on_image, tuple(start_pixel), tuple(end_pixel), rgb_color, thickness=ARROW_THICKNESS_IN_PIXELS, tipLength=0.4
+        on_image,
+        tuple(start_pixel.astype(np.int32)),
+        tuple(end_pixel.astype(np.int32)),
+        rgb_color,
+        thickness=ARROW_THICKNESS_IN_PIXELS,
+        tipLength=1.8,
     )
 
 


### PR DESCRIPTION
Fix an issue affecting arrow visualisation. Refactor code to use cv2 rotation matrix.
NOTE: In the following 2 pictures the arrows have been magnified and their number reduced

BEFORE
<img width="286" alt="Screenshot 2020-07-16 at 13 31 26" src="https://user-images.githubusercontent.com/27865235/87666458-f211cb00-c768-11ea-8ca3-ad30c6ee2588.png">

AFTER:
<img width="286" alt="Screenshot 2020-07-16 at 13 32 10" src="https://user-images.githubusercontent.com/27865235/87666481-fc33c980-c768-11ea-8b19-8fe12bcb6281.png">

NOTE: I've increased the tip length, now arrows look like:
<img width="286" alt="Screenshot 2020-07-16 at 13 36 24" src="https://user-images.githubusercontent.com/27865235/87666696-5fbdf700-c769-11ea-918b-a819e5d0761f.png">

Are we fine with that? 