### PR TITLE
Change agent_mask check

### DIFF
--- a/l5kit/l5kit/dataset/agent.py
+++ b/l5kit/l5kit/dataset/agent.py
@@ -44,9 +44,8 @@ class AgentDataset(EgoDataset):
         """
         agent_prob = self.cfg["raster_params"]["filter_agents_threshold"]
 
-        try:
-            agents_mask = self.dataset.root[f"agents_mask/{agent_prob}"]
-        except KeyError:
+        agents_mask_path = Path(self.dataset.path) / f"agents_mask/{agent_prob}"
+        if not agents_mask_path.exists():  # don't check in root but check for the path
             print(
                 f"cannot find the right config in {self.dataset.path},\n"
                 f"your cfg has loaded filter_agents_threshold={agent_prob};\n"
@@ -61,9 +60,7 @@ class AgentDataset(EgoDataset):
                 th_distance_av=TH_DISTANCE_AV,
             )
 
-            array_path = Path(self.dataset.path) / f"agents_mask/{agent_prob}"
-            agents_mask = convenience.load(str(array_path))  # note (lberg): this doesn't update root
-
+        agents_mask = convenience.load(str(agents_mask_path))  # note (lberg): this doesn't update root
         return agents_mask
 
     def __len__(self) -> int:

--- a/l5kit/l5kit/dataset/select_agents.py
+++ b/l5kit/l5kit/dataset/select_agents.py
@@ -6,6 +6,7 @@ from collections import Counter, defaultdict
 from functools import partial
 from multiprocessing import Pool, cpu_count
 from pathlib import Path
+from tempfile import gettempdir
 from typing import Tuple
 from uuid import uuid4
 
@@ -157,9 +158,10 @@ def select_agents(
     """
     Filter agents from zarr INPUT_FOLDER according to multiple thresholds and store a boolean array of the same shape.
     """
+    agents_mask_path = Path(zarr_dataset.path) / f"agents_mask/{th_agent_prob}"
 
-    if (Path(zarr_dataset.path) / f"agents_mask/{th_agent_prob}").exists():
-        raise FileExistsError(f"{th_agent_prob} exists already! only one is supported for now!")
+    if agents_mask_path.exists():
+        raise FileExistsError(f"{th_agent_prob} exists already! only one is supported!")
 
     frame_index_intervals = zarr_dataset.scenes["frame_index_interval"]
 
@@ -180,12 +182,12 @@ def select_agents(
         pass  # group is already there
 
     agents_mask = zarr.open_array(
-        str(Path(zarr_dataset.path) / "agents_mask" / f"{th_agent_prob}"),
+        str(agents_mask_path),
         mode="w",
         shape=(len(zarr_dataset.agents), 2),
         chunks=(10000,),
         dtype=np.uint32,
-        synchronizer=zarr.ProcessSynchronizer(f"/tmp/ag_mask_{str(uuid4())}.sync"),
+        synchronizer=zarr.ProcessSynchronizer(Path(gettempdir()) / f"ag_mask_{str(uuid4())}.sync"),
     )
 
     report: Counter = Counter()

--- a/l5kit/l5kit/dataset/select_agents.py
+++ b/l5kit/l5kit/dataset/select_agents.py
@@ -158,9 +158,8 @@ def select_agents(
     Filter agents from zarr INPUT_FOLDER according to multiple thresholds and store a boolean array of the same shape.
     """
 
-    output_group = f"{th_agent_prob}"
-    if "agents_mask" in zarr_dataset.root and f"agents_mask/{output_group}" in zarr_dataset.root:
-        raise FileExistsError(f"{output_group} exists already! only one is supported for now!")
+    if (Path(zarr_dataset.path) / f"agents_mask/{th_agent_prob}").exists():
+        raise FileExistsError(f"{th_agent_prob} exists already! only one is supported for now!")
 
     frame_index_intervals = zarr_dataset.scenes["frame_index_interval"]
 
@@ -181,7 +180,7 @@ def select_agents(
         pass  # group is already there
 
     agents_mask = zarr.open_array(
-        str(Path(zarr_dataset.path) / "agents_mask" / output_group),
+        str(Path(zarr_dataset.path) / "agents_mask" / f"{th_agent_prob}"),
         mode="w",
         shape=(len(zarr_dataset.agents), 2),
         chunks=(10000,),

--- a/l5kit/l5kit/tests/evaluation/compute_mse_loss_test.py
+++ b/l5kit/l5kit/tests/evaluation/compute_mse_loss_test.py
@@ -11,7 +11,6 @@ def test_compute_mse_error(tmp_path: Path) -> None:
     data = ChunkedStateDataset(path="./l5kit/tests/artefacts/single_scene.zarr")
     data.open()
     export_zarr_to_ground_truth_csv(data, str(tmp_path / "gt1.csv"), 0, 50, 0.5)
-    data.open()  # avoid double select_agents
     export_zarr_to_ground_truth_csv(data, str(tmp_path / "gt2.csv"), 0, 50, 0.5)
     err = compute_mse_error_csv(str(tmp_path / "gt1.csv"), str(tmp_path / "gt2.csv"))
     assert np.all(err == 0.0)
@@ -20,7 +19,6 @@ def test_compute_mse_error(tmp_path: Path) -> None:
     data_fake.scenes = np.asarray(data.scenes).copy()
     data_fake.frames = np.asarray(data.frames).copy()
     data_fake.agents = np.asarray(data.agents).copy()
-    data_fake.root = data.root
     data_fake.agents["centroid"] += np.random.rand(*data_fake.agents["centroid"].shape)
 
     export_zarr_to_ground_truth_csv(data_fake, str(tmp_path / "gt3.csv"), 0, 50, 0.5)

--- a/l5kit/l5kit/tests/evaluation/compute_mse_loss_test.py
+++ b/l5kit/l5kit/tests/evaluation/compute_mse_loss_test.py
@@ -19,7 +19,7 @@ def test_compute_mse_error(tmp_path: Path) -> None:
     data_fake.scenes = np.asarray(data.scenes).copy()
     data_fake.frames = np.asarray(data.frames).copy()
     data_fake.agents = np.asarray(data.agents).copy()
-    data_fake.agents["centroid"] += np.random.rand(*data_fake.agents["centroid"].shape)
+    data_fake.agents["centroid"] += np.random.rand(*data_fake.agents["centroid"].shape) * 1e-2
 
     export_zarr_to_ground_truth_csv(data_fake, str(tmp_path / "gt3.csv"), 0, 50, 0.5)
     err = compute_mse_error_csv(str(tmp_path / "gt1.csv"), str(tmp_path / "gt3.csv"))


### PR DESCRIPTION
Instead of checking the group for the `agents_mask`, check directly the full path.
This avoids calling multiple `select_agents` if the root is not updated (can be updated only by calling `open()` again, but that replace arrays).