### PR TITLE
Lberg/semantic pose

### DIFF
--- a/.github/workflows/l5kit.yml
+++ b/.github/workflows/l5kit.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [ master ]
   pull_request:
-    branches: [ * ]
 
 jobs:
   CI-build:

--- a/.github/workflows/l5kit.yml
+++ b/.github/workflows/l5kit.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ master ]
   pull_request:
-    branches: [ master ]
+    branches: [ * ]
 
 jobs:
   CI-build:

--- a/l5kit/l5kit/data/map.py
+++ b/l5kit/l5kit/data/map.py
@@ -30,7 +30,7 @@ def unpack_crosswalk(e: TrafficControlElement, g: GeoFrame, ecef_to_pose: np.nda
 
 
 @no_type_check
-def proto_to_semantic_map(map_fragment: "MapFragment", ecef_to_pose: np.ndarray) -> dict:
+def proto_to_semantic_map(map_fragment: MapFragment, ecef_to_pose: np.ndarray) -> dict:
     """Loads and does preprocessing of given semantic map in binary proto format.
 
     Args:

--- a/l5kit/l5kit/data/map.py
+++ b/l5kit/l5kit/data/map.py
@@ -3,39 +3,39 @@ from typing import Sequence, no_type_check
 import numpy as np
 import pymap3d as pm
 
+from ..geometry import transform_points
 from .proto.road_network_pb2 import GeoFrame, Lane, MapFragment, TrafficControlElement
-
-# store data in enu frame around origin lat, lon
-LAT = 37.4108709
-LON = -122.1462192
 
 
 @no_type_check
-def unpack_deltas_cm(dx: Sequence[int], dy: Sequence[int], dz: Sequence[int], g: GeoFrame) -> np.ndarray:
+def unpack_deltas_cm(
+    dx: Sequence[int], dy: Sequence[int], dz: Sequence[int], g: GeoFrame, ecef_to_pose: np.ndarray
+) -> np.ndarray:
     x = np.cumsum(np.asarray(dx) / 100)
     y = np.cumsum(np.asarray(dy) / 100)
     z = np.cumsum(np.asarray(dz) / 100)
-    x, y, z = pm.enu2ecef(x, y, z, g.origin.lat_e7 * 1e-7, g.origin.lng_e7 * 1e-7, 0)
-    x, y, z = pm.ecef2enu(x, y, z, LAT, LON, 0)
-    return np.stack([x, y, z])
+    xyz = np.stack(pm.enu2ecef(x, y, z, g.origin.lat_e7 * 1e-7, g.origin.lng_e7 * 1e-7, 0), axis=-1)
+    xyz = transform_points(xyz, ecef_to_pose)
+    return xyz
 
 
 @no_type_check
-def unpack_boundary(b: Lane.Boundary, g: GeoFrame) -> np.ndarray:
-    return unpack_deltas_cm(b.vertex_deltas_x_cm, b.vertex_deltas_y_cm, b.vertex_deltas_z_cm, g)
+def unpack_boundary(b: Lane.Boundary, g: GeoFrame, ecef_to_pose: np.ndarray) -> np.ndarray:
+    return unpack_deltas_cm(b.vertex_deltas_x_cm, b.vertex_deltas_y_cm, b.vertex_deltas_z_cm, g, ecef_to_pose)
 
 
 @no_type_check
-def unpack_crosswalk(e: TrafficControlElement, g: GeoFrame) -> np.ndarray:
-    return unpack_deltas_cm(e.points_x_deltas_cm, e.points_y_deltas_cm, e.points_z_deltas_cm, g)
+def unpack_crosswalk(e: TrafficControlElement, g: GeoFrame, ecef_to_pose: np.ndarray) -> np.ndarray:
+    return unpack_deltas_cm(e.points_x_deltas_cm, e.points_y_deltas_cm, e.points_z_deltas_cm, g, ecef_to_pose)
 
 
 @no_type_check
-def proto_to_semantic_map(map_fragment: "MapFragment") -> dict:
+def proto_to_semantic_map(map_fragment: "MapFragment", ecef_to_pose: np.ndarray) -> dict:
     """Loads and does preprocessing of given semantic map in binary proto format.
 
     Args:
         map_fragment (MapFragment): the external wrapper of the map's elements.
+        ecef_to_pose (np.ndarray): ecef_to_pose matrix
 
     Returns:
         dict: A dict containing the semantic map contents.
@@ -54,37 +54,32 @@ def proto_to_semantic_map(map_fragment: "MapFragment") -> dict:
             lane = element.element.lane
 
             # get left-right coordinates and element id
-            x_left, y_left, z_left = unpack_boundary(lane.left_boundary, lane.geo_frame)
-            x_right, y_right, z_right = unpack_boundary(lane.right_boundary, lane.geo_frame)
-            lanes.append(
-                {
-                    "xyz_left": (x_left, y_left, z_left),
-                    "xyz_right": (x_right, y_right, z_right),
-                    "id": element.id.id.decode("utf-8"),
-                }
-            )
+            xyz_left = unpack_boundary(lane.left_boundary, lane.geo_frame, ecef_to_pose)
+            xyz_right = unpack_boundary(lane.right_boundary, lane.geo_frame, ecef_to_pose)
+            lanes.append({"xyz_left": xyz_left, "xyz_right": xyz_right, "id": element.id.id.decode("utf-8")})
+
             # store bounds for fast rasterisation look-up
-            x_min = min(np.min(x_left), np.min(x_right))
-            y_min = min(np.min(y_left), np.min(y_right))
-            x_max = max(np.max(x_left), np.max(x_right))
-            y_max = max(np.max(y_left), np.max(y_right))
+            x_min = min(np.min(xyz_left[:, 0]), np.min(xyz_right[:, 0]))
+            y_min = min(np.min(xyz_left[:, 1]), np.min(xyz_right[:, 1]))
+            x_max = max(np.max(xyz_left[:, 0]), np.max(xyz_right[:, 0]))
+            y_max = max(np.max(xyz_left[:, 1]), np.max(xyz_right[:, 1]))
             lanes_bounds = np.append(lanes_bounds, np.asarray([[[x_min, y_min], [x_max, y_max]]]), axis=0)
 
         if element.element.HasField("traffic_control_element"):
             traffic_element = element.element.traffic_control_element
 
             if traffic_element.HasField("pedestrian_crosswalk") and traffic_element.points_x_deltas_cm:
-                x, y, z = unpack_crosswalk(traffic_element, traffic_element.geo_frame)
+                xyz = unpack_crosswalk(traffic_element, traffic_element.geo_frame, ecef_to_pose)
 
-                crosswalks.append({"xyz": (x, y, z), "id": element.id.id.decode("utf-8")})
+                crosswalks.append({"xyz": xyz, "id": element.id.id.decode("utf-8")})
 
                 crosswalks_bounds = np.append(
-                    crosswalks_bounds, np.asarray([[[np.min(x), np.min(y)], [np.max(x), np.max(y)]]]), axis=0
+                    crosswalks_bounds,
+                    np.asarray([[[np.min(xyz[:, 0]), np.min(xyz[:, 1])], [np.max(xyz[:, 0]), np.max(xyz[:, 1])]]]),
+                    axis=0,
                 )
 
     return {
-        "lat": LAT,
-        "lon": LON,
         "lanes": lanes,
         "lanes_bounds": lanes_bounds,
         "crosswalks": crosswalks,

--- a/l5kit/l5kit/rasterization/semantic_rasterizer.py
+++ b/l5kit/l5kit/rasterization/semantic_rasterizer.py
@@ -118,8 +118,8 @@ class SemanticRasterizer(Rasterizer):
 
         img = 255 * np.ones(shape=(self.raster_size[1], self.raster_size[0], 3), dtype=np.uint8)
 
-        # TODO this can be speed up by looking at the image corners coordinates
-        radius = float(np.linalg.norm(self.raster_size * self.pixel_size))  # compute a radius around the center
+        # filter using half the radius from the center
+        radius = float(np.linalg.norm(self.raster_size * self.pixel_size)) / 2
 
         # plot lanes
         lanes_lines = []

--- a/l5kit/l5kit/rasterization/semantic_rasterizer.py
+++ b/l5kit/l5kit/rasterization/semantic_rasterizer.py
@@ -18,14 +18,14 @@ def elements_within_bounds(center: np.ndarray, bounds: np.ndarray, half_side: fl
     center (squared with side 2*radius)
 
     Args:
-        center (float): XYZ of the center
+        center (float): XY of the center
         bounds (np.ndarray): array of shape Nx2x2 [[x_min,y_min],[x_max, y_max]]
         half_side (float): half the side of the bounding box centered around center
 
     Returns:
         np.ndarray: indices of elements inside radius from center
     """
-    x_center, y_center, z_center = center
+    x_center, y_center = center
 
     x_min_in = x_center > bounds[:, 0, 0] - half_side
     y_min_in = y_center > bounds[:, 0, 1] - half_side
@@ -98,10 +98,9 @@ class SemanticRasterizer(Rasterizer):
             self.raster_size, self.pixel_size, ego_translation, ego_yaw, self.ego_center,
         )
 
-        # get XYZ of center pixel in world coordinate
+        # get XY of center pixel in world coordinate
         center_pixel = np.asarray(self.raster_size) * (0.5, 0.5)
         center_world = transform_point(center_pixel, np.linalg.inv(world_to_image_space))
-        center_world = np.append(center_world, ego_translation[2])
 
         sem_im = self.render_semantic_map(center_world, world_to_image_space)
         return sem_im.astype(np.float32) / 255
@@ -110,7 +109,7 @@ class SemanticRasterizer(Rasterizer):
         """Renders the semantic map at given x,y coordinates.
 
         Args:
-            center_world (np.ndarray): XYZ of the image center in world ref system
+            center_world (np.ndarray): XY of the image center in world ref system
             world_to_image_space (np.ndarray):
         Returns:
             np.ndarray: RGB raster

--- a/l5kit/l5kit/rasterization/semantic_rasterizer.py
+++ b/l5kit/l5kit/rasterization/semantic_rasterizer.py
@@ -9,21 +9,6 @@ from ..geometry import rotation33_as_yaw, transform_point, transform_points, wor
 from .rasterizer import Rasterizer
 
 
-# TODO refactor and explain what's happening
-def map_to_image(
-    x: float,
-    y: float,
-    yaw: float,
-    px: np.ndarray,
-    py: np.ndarray,
-    raster_size: Tuple[int, int],
-    pixel_size: np.ndarray,
-) -> Tuple[np.ndarray, np.ndarray]:
-    rx = (np.cos(yaw) * (px - x) - np.sin(yaw) * (py - y)) / pixel_size[0] + 0.5 * raster_size[0]
-    ry = (np.sin(yaw) * (px - x) + np.cos(yaw) * (py - y)) / pixel_size[1] + 0.5 * raster_size[1]
-    return rx.astype(int) * 256, ry.astype(int) * 256
-
-
 def elements_within_radius(x: float, y: float, bounds: np.ndarray, radius: float) -> np.ndarray:
     """
     Get indices of elements for which bounds are inside a radius from center (x,y)

--- a/l5kit/l5kit/rasterization/semantic_rasterizer.py
+++ b/l5kit/l5kit/rasterization/semantic_rasterizer.py
@@ -83,7 +83,6 @@ class SemanticRasterizer(Rasterizer):
         world_translation = transform_point(center_pixel, np.linalg.inv(world_to_image_space))
         xyz = np.append(world_translation, ego_translation[2])
 
-        # TODO (lberg): understand -yaw here in relation with map_to_image
         sem_im = self.render_semantic_map(xyz[0], xyz[1], world_to_image_space)
         return sem_im.astype(np.float32) / 255
 

--- a/l5kit/l5kit/tests/rasterization/sem_rasterizer_test.py
+++ b/l5kit/l5kit/tests/rasterization/sem_rasterizer_test.py
@@ -1,0 +1,44 @@
+import numpy as np
+
+from l5kit.rasterization.semantic_rasterizer import elements_within_bounds
+
+
+def test_elements_within_bounds() -> None:
+    center = np.zeros(2)
+    half_side = 0.5  # square centered on origin with side 1
+    bounds = np.zeros((1, 2, 2))
+
+    # non-intersecting
+    bounds[0, 0] = (2, 2)
+    bounds[0, 1] = (4, 4)
+    assert len(elements_within_bounds(center, bounds, half_side)) == 0
+
+    # intersecting only x
+    bounds[0, 0] = (0, 2)
+    bounds[0, 1] = (4, 4)
+    assert len(elements_within_bounds(center, bounds, half_side)) == 0
+
+    # intersecting only y
+    bounds[0, 0] = (2, 0)
+    bounds[0, 1] = (4, 4)
+    assert len(elements_within_bounds(center, bounds, half_side)) == 0
+
+    # intersecting both with min (valid)
+    bounds[0, 0] = (0.25, 0.25)
+    bounds[0, 1] = (4, 4)
+    assert len(elements_within_bounds(center, bounds, half_side)) == 1
+
+    # intersecting both with max (valid)
+    bounds[0, 0] = (-4, -4)
+    bounds[0, 1] = (0.25, 0.25)
+    assert len(elements_within_bounds(center, bounds, half_side)) == 1
+
+    # inside (valid)
+    bounds[0, 0] = (-0.25, -0.25)
+    bounds[0, 1] = (0.25, 0.25)
+    assert len(elements_within_bounds(center, bounds, half_side)) == 1
+
+    # including (valid)
+    bounds[0, 0] = (-4, -4)
+    bounds[0, 1] = (4, 4)
+    assert len(elements_within_bounds(center, bounds, half_side)) == 1

--- a/l5kit/l5kit/tests/rasterization/sem_rasterizer_test.py
+++ b/l5kit/l5kit/tests/rasterization/sem_rasterizer_test.py
@@ -5,7 +5,7 @@ from l5kit.rasterization.semantic_rasterizer import elements_within_bounds
 
 def test_elements_within_bounds() -> None:
     center = np.zeros(2)
-    half_side = 0.5  # square centered on origin with side 1
+    half_side = 0.5  # square centered around origin with side 1
     bounds = np.zeros((1, 2, 2))
 
     # non-intersecting


### PR DESCRIPTION
Add the following:
- refactor `SemanticRasterizer` and protobuf utility function to work with world coordinates and not local ENU;
- use `world_to_image` matrix into `SemanticRasterizer`
- reduce ROI for lane search to half the size of the hypotenuse from the image centre (2x performance)
- add some tests