### PR TITLE
move default dataset meta path, add warning for cv2 on macOS

### DIFF
--- a/examples/agent_motion_prediction/agent_motion_config.yaml
+++ b/examples/agent_motion_prediction/agent_motion_config.yaml
@@ -34,7 +34,7 @@ raster_params:
   # the keys are relative to the dataset environment variable
   satellite_map_key: "aerial_map/aerial_map.png"
   semantic_map_key: "semantic_map/semantic_map.pb"
-  dataset_meta_key: "meta.json"
+  dataset_meta_key: "semantic_map/meta.json"
 
   # e.g. 0.0 include every obstacle, 0.5 show those obstacles with >0.5 probability of being
   # one of the classes we care about (cars, bikes, peds, etc.), >=1.0 filter all other agents.

--- a/examples/agent_motion_prediction/agent_motion_prediction.ipynb
+++ b/examples/agent_motion_prediction/agent_motion_prediction.ipynb
@@ -159,8 +159,8 @@
    "source": [
     "# Training\n",
     "\n",
-    "note: if you're on MacOS and you're using `py_satellite` rasterizer, you may need to disable opencv multiprocessing by adding:\n",
-    "`cv2.setNumThreads(0)` before the following cell. This seems to only affect running in python notebook and it's cause by the `cv2.warpaffine` function"
+    "note: if you're on MacOS and using `py_satellite` rasterizer, you may need to disable opencv multiprocessing by adding:\n",
+    "`cv2.setNumThreads(0)` before the following cell. This seems to only affect running in python notebook and it's caused by the `cv2.warpaffine` function"
    ]
   },
   {

--- a/examples/agent_motion_prediction/agent_motion_prediction.ipynb
+++ b/examples/agent_motion_prediction/agent_motion_prediction.ipynb
@@ -157,7 +157,10 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Training"
+    "# Training\n",
+    "\n",
+    "note: if you're on MacOS and you're using `py_satellite` rasterizer, you may need to disable opencv multiprocessing by adding:\n",
+    "`cv2.setNumThreads(0)` before this cell"
    ]
   },
   {
@@ -409,7 +412,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.3"
+   "version": "3.6.8"
   },
   "pycharm": {
    "stem_cell": {

--- a/examples/agent_motion_prediction/agent_motion_prediction.ipynb
+++ b/examples/agent_motion_prediction/agent_motion_prediction.ipynb
@@ -160,7 +160,7 @@
     "# Training\n",
     "\n",
     "note: if you're on MacOS and you're using `py_satellite` rasterizer, you may need to disable opencv multiprocessing by adding:\n",
-    "`cv2.setNumThreads(0)` before this cell"
+    "`cv2.setNumThreads(0)` before the following cell. This seems to only affect running in python notebook and it's cause by the `cv2.warpaffine` function"
    ]
   },
   {
@@ -412,7 +412,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "version": "3.8.3"
   },
   "pycharm": {
    "stem_cell": {

--- a/examples/visualisation/visualisation_config.yaml
+++ b/examples/visualisation/visualisation_config.yaml
@@ -34,7 +34,7 @@ raster_params:
   # the keys are relative to the dataset environment variable
   satellite_map_key: "aerial_map/aerial_map.png"
   semantic_map_key: "semantic_map/semantic_map.pb"
-  dataset_meta_key: "meta.json"
+  dataset_meta_key: "semantic_map/meta.json"
 
   # e.g. 0.0 include every obstacle, 0.5 show those obstacles with >0.5 probability of being
   # one of the classes we care about (cars, bikes, peds, etc.), >=1.0 filter all other agents.


### PR DESCRIPTION
Move default dataset meta path into `semantic_map`. As a dataset is tied to it's semantic map it makes sense to have it there

Update: it will be moved yet again as we have decided on a different structure for the dataset

Also, add a note for training on macOS using the `py_satellite`. In this case opencv `warpAffine` breaks because of multi-processing. A quick fix is to disable cv2 multi-processing