### PR TITLE
add dim to target availibitily

### DIFF
--- a/l5kit/l5kit/sampling/agent_sampling.py
+++ b/l5kit/l5kit/sampling/agent_sampling.py
@@ -186,7 +186,7 @@ def _create_targets_for_deep_prediction(
     # How much the coordinates differ from the current state in meters.
     coords_offset = np.zeros((num_frames, 2), dtype=np.float32)
     yaws_offset = np.zeros((num_frames, 1), dtype=np.float32)
-    availability = np.zeros((num_frames,), dtype=np.float32)
+    availability = np.zeros((num_frames, 1), dtype=np.float32)
 
     for i, (frame, agents) in enumerate(zip(frames, agents)):
         if selected_track_id is None:


### PR DESCRIPTION
I revert the dimension change in `target_availability` (from `(num_frames)` back to `(num_frames, 1)`).
Because it breaks tensor multiplication in avresearch drivenet model, where we perform `data_batch["target_availabilities"] * self.weights_scaling)` -> `(num_batch, num_frames, 1) x (3)`

PTAL @lucabergamini 
