### PR TITLE
rename same-name loop variable

### DIFF
--- a/l5kit/l5kit/sampling/agent_sampling.py
+++ b/l5kit/l5kit/sampling/agent_sampling.py
@@ -190,14 +190,14 @@ def _create_targets_for_deep_prediction(
     yaws_offset = np.zeros((num_frames, 1), dtype=np.float32)
     availability = np.zeros((num_frames,), dtype=np.float32)
 
-    for i, (frame, agents) in enumerate(zip(frames, agents)):
+    for i, (frame, frame_agents) in enumerate(zip(frames, agents)):
         if selected_track_id is None:
             agent_centroid = frame["ego_translation"][:2]
             agent_yaw = rotation33_as_yaw(frame["ego_rotation"])
         else:
             # it's not guaranteed the target will be in every frame
             try:
-                agent = filter_agents_by_track_id(agents, selected_track_id)[0]
+                agent = filter_agents_by_track_id(frame_agents, selected_track_id)[0]
             except IndexError:
                 availability[i] = 0.0  # keep track of invalid futures/history
                 continue


### PR DESCRIPTION
We are using the same name for the looped variable and the item, see #137 

A minimal example of the issue follows:
```python
els = [1,2,3]
for els in els:
    print(els)
```

Note this is perfectly legal in Python ( my guess is that the iterable is store as a ref so reassigning the name doesn't affect it) and produces
```
1
2
3
```
as expected. Still, we should change the name for clarity