### PR TITLE
[CI] run github ci on various torch versions

### DIFF
--- a/.github/workflows/l5kit.yml
+++ b/.github/workflows/l5kit.yml
@@ -2,7 +2,7 @@ name: L5Kit-tests
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
 
 jobs:
@@ -11,6 +11,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.6, 3.7, 3.8]
+        torch-deps: [15, 16]
 
     steps:
     - uses: actions/checkout@v2
@@ -22,6 +23,7 @@ jobs:
       working-directory: l5kit
       run: |
         python -m pip install --upgrade pip
+        pip install -r requirements_torch${{ matrix.torch-deps }}.txt
         pip install -r requirements.txt
     - name: Lint project
       working-directory: l5kit

--- a/l5kit/requirements_torch15.txt
+++ b/l5kit/requirements_torch15.txt
@@ -1,0 +1,2 @@
+torch>=1.5,<1.6
+torchvision>=0.6,<0.7

--- a/l5kit/requirements_torch16.txt
+++ b/l5kit/requirements_torch16.txt
@@ -1,0 +1,2 @@
+torch>=1.6,<1.7
+torchvision>=0.7,<0.8


### PR DESCRIPTION
I added in a previous PR to allow torch 1.6, but I think we can allow GitHub to capture this various versions in a matrix.