### PR TITLE
add subpixel precision to BoxRasteriser

### DIFF
--- a/l5kit/l5kit/rasterization/box_rasterizer.py
+++ b/l5kit/l5kit/rasterization/box_rasterizer.py
@@ -9,6 +9,7 @@ from ..data.filter import filter_agents_by_labels, filter_agents_by_track_id
 from ..geometry import rotation33_as_yaw, transform_points, world_to_image_pixels_matrix
 from ..geometry.transform import yaw_as_rotation33
 from .rasterizer import EGO_EXTENT_HEIGHT, EGO_EXTENT_LENGTH, EGO_EXTENT_WIDTH, Rasterizer
+from .semantic_rasterizer import CV2_SHIFT, cv2_subpixel
 
 
 def get_ego_as_agent(frame: np.ndarray) -> np.ndarray:  # TODO this can be useful to have around
@@ -65,8 +66,8 @@ def draw_boxes(
     box_image_coords = transform_points(box_world_coords.reshape((-1, 2)), world_to_image_space)
 
     # fillPoly wants polys in a sequence with points inside as (x,y)
-    box_image_coords = box_image_coords.reshape((-1, 4, 2)).astype(np.int64)
-    cv2.fillPoly(im, box_image_coords, color=color)
+    box_image_coords = cv2_subpixel(box_image_coords.reshape((-1, 4, 2)))
+    cv2.fillPoly(im, box_image_coords, color=color, shift=CV2_SHIFT)
     return im
 
 

--- a/l5kit/l5kit/rasterization/box_rasterizer.py
+++ b/l5kit/l5kit/rasterization/box_rasterizer.py
@@ -67,7 +67,7 @@ def draw_boxes(
 
     # fillPoly wants polys in a sequence with points inside as (x,y)
     box_image_coords = cv2_subpixel(box_image_coords.reshape((-1, 4, 2)))
-    cv2.fillPoly(im, box_image_coords, color=color, shift=CV2_SHIFT)
+    cv2.fillPoly(im, box_image_coords, color=color, lineType=cv2.LINE_AA, shift=CV2_SHIFT)
     return im
 
 

--- a/l5kit/l5kit/tests/rasterization/box_rasterizer_test.py
+++ b/l5kit/l5kit/tests/rasterization/box_rasterizer_test.py
@@ -15,16 +15,23 @@ def test_empty_boxes() -> None:
 
 
 def test_draw_boxes() -> None:
+    centroid_1 = (90, 100)
+    centroid_2 = (150, 160)
+
     agents = np.zeros(2, dtype=AGENT_DTYPE)
     agents[0]["extent"] = (20, 20, 20)
-    agents[0]["centroid"] = (100, 100)
+    agents[0]["centroid"] = centroid_1
 
     agents[1]["extent"] = (20, 20, 20)
-    agents[1]["centroid"] = (150, 150)
+    agents[1]["centroid"] = centroid_2
 
     to_image_space = np.eye(3)
     im = draw_boxes((200, 200), to_image_space, agents, color=1)
-    assert im.sum() == (21 * 21) * 2
+
+    # due to subpixel precision we can't check the exact number of pixels
+    # check that a 10x10 centred on the boxes is all 1
+    assert np.allclose(im[centroid_1[1] - 5 : centroid_1[1] + 5, centroid_1[0] - 5 : centroid_1[0] + 5], 1)
+    assert np.allclose(im[centroid_2[1] - 5 : centroid_2[1] + 5, centroid_2[0] - 5 : centroid_2[0] + 5], 1)
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
Add subpixel precision to BoxRasterizer also

Note:
 I had to remove the `LINE_AA` flag as it was making a test failing (and also resulting boxes had the corner cut)