### PR TITLE
allow users to limit the number of history frames to rasterize

### DIFF
--- a/examples/agent_motion_prediction/agent_motion_config.yaml
+++ b/examples/agent_motion_prediction/agent_motion_config.yaml
@@ -43,6 +43,10 @@ raster_params:
   # whether to completely disable traffic light faces in the semantic rasterizer
   disable_traffic_light_faces: False
 
+  # if you want a larger number of history frames but would not want to rasterize them all
+  # this will override .model_params.history_num_frames
+  # history_num_frames_to_rasterize: 0
+
 ###################
 ## Data loader options
 train_data_loader:

--- a/l5kit/l5kit/rasterization/box_rasterizer.py
+++ b/l5kit/l5kit/rasterization/box_rasterizer.py
@@ -1,3 +1,4 @@
+from itertools import islice
 from typing import List, Optional, Tuple, Union
 
 import cv2
@@ -112,7 +113,7 @@ class BoxRasterizer(Rasterizer):
         agents_images = np.zeros(out_shape, dtype=np.uint8)
         ego_images = np.zeros(out_shape, dtype=np.uint8)
 
-        for i, (frame, agents) in enumerate(zip(history_frames, history_agents)):
+        for i, (frame, agents) in enumerate(islice(zip(history_frames, history_agents), out_shape[2])):
             agents = filter_agents_by_labels(agents, self.filter_agents_threshold)
             # note the cast is for legacy support of dataset before April 2020
             av_agent = get_ego_as_agent(frame).astype(agents.dtype)

--- a/l5kit/l5kit/rasterization/rasterizer_builder.py
+++ b/l5kit/l5kit/rasterization/rasterizer_builder.py
@@ -131,6 +131,19 @@ def build_rasterizer(cfg: dict, data_manager: DataManager) -> Rasterizer:
     filter_agents_threshold = raster_cfg["filter_agents_threshold"]
     history_num_frames = cfg["model_params"]["history_num_frames"]
 
+    if "history_num_frames_to_rasterize" in raster_cfg:
+        _override_val = raster_cfg["history_num_frames_to_rasterize"]
+        assert 0 <= _override_val <= history_num_frames, (
+            f".raster_params.history_num_frames_to_rasterize ({_override_val}) should be in"
+            " the range of [0, history_num_frames]"
+        )
+        print(
+            "You have overridden history_num_frames in the rasterizer,",
+            f"which means you will have {history_num_frames} frames of raw data but only",
+            f"{_override_val} rasterized as images",
+        )
+        history_num_frames = _override_val
+
     if map_type in ["py_satellite", "satellite_debug"]:
         sat_image = _load_satellite_map(raster_cfg["satellite_map_key"], data_manager)
 

--- a/l5kit/l5kit/tests/dataset/dataset_test.py
+++ b/l5kit/l5kit/tests/dataset/dataset_test.py
@@ -1,4 +1,3 @@
-from copy import deepcopy
 from typing import Callable
 
 import numpy as np
@@ -42,7 +41,6 @@ def check_torch_loading(dataset: Dataset) -> None:
 def test_dataset_rasterizer(
     rast_name: str, dataset_cls: Callable, zarr_dataset: ChunkedDataset, dmg: LocalDataManager, cfg: dict
 ) -> None:
-    cfg = deepcopy(cfg)
     cfg["raster_params"]["map_type"] = rast_name
     rasterizer = build_rasterizer(cfg, dmg)
 
@@ -56,7 +54,6 @@ def test_dataset_rasterizer(
 def test_dataset_rasterizer_with_override(
     rast_name: str, dataset_cls: Callable, zarr_dataset: ChunkedDataset, dmg: LocalDataManager, cfg: dict
 ) -> None:
-    cfg = deepcopy(cfg)
     cfg["raster_params"]["map_type"] = rast_name
     cfg["model_params"]["history_num_frames"] = 1
     cfg["raster_params"]["history_num_frames_to_rasterize"] = 0

--- a/l5kit/l5kit/tests/rasterization/box_rasterizer_test.py
+++ b/l5kit/l5kit/tests/rasterization/box_rasterizer_test.py
@@ -102,7 +102,7 @@ def test_out_shape_override(hist_data: tuple, dmg: LocalDataManager, cfg: dict, 
     assert out.shape == (224, 224, (real_length + 1) * 2)
 
 
-@pytest.mark.parametrize("lengths", [(5, 6), (5, -1), (5, "1")])
+@pytest.mark.parametrize("lengths", [(5, 6), (5, -1)])
 def test_out_shape_override_err_config(
     hist_data: tuple, dmg: LocalDataManager, cfg: dict, lengths: Tuple[int, Any]
 ) -> None:

--- a/l5kit/setup.py
+++ b/l5kit/setup.py
@@ -28,12 +28,24 @@ setup(
         "pyyaml",
         "notebook",
         "ptable",
-        "ipywidgets"
+        "ipywidgets",
     ],
     extras_require={
-        "dev": ["pytest", "mypy", "setuptools", "twine", "wheel", "pytest-cov", "flake8",
-                "black==19.10b0", "isort", "Sphinx", "sphinx-rtd-theme", "recommonmark",
-                "pre-commit"]
+        "dev": [
+            "pytest",
+            "mypy",
+            "setuptools",
+            "twine",
+            "wheel",
+            "pytest-cov",
+            "flake8",
+            "black==19.10b0",
+            "isort",
+            "Sphinx",
+            "sphinx-rtd-theme",
+            "recommonmark",
+            "pre-commit",
+        ]
     },
     packages=find_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests"]),
     classifiers=[


### PR DESCRIPTION
for now the configurations for rasterizing history frames and for returning within the batch data are tightly coupled, if one wants to use more historical context and do not need those history frames to be rasterized as boxes, an exit hatch can be handy.