### PR TITLE
allow rasterizer and returned image to be None

### DIFF
--- a/l5kit/l5kit/dataset/ego.py
+++ b/l5kit/l5kit/dataset/ego.py
@@ -79,8 +79,9 @@ None if not desired
             state_index (int): a relative frame index in the scene
             track_id (Optional[int]): the agent to rasterize or None for the AV
         Returns:
-            dict: the rasterised image, the target trajectory (position and yaw) along with their availability,
-            the 2D matrix to center that agent, the agent track (-1 if ego) and the timestamp
+            dict: the rasterised image in (Cx0x1) if the rast is not None, the target trajectory
+            (position and yaw) along with their availability, the 2D matrix to center that agent,
+            the agent track (-1 if ego) and the timestamp
 
         """
         frames = self.dataset.frames[get_frames_slice_from_scenes(self.dataset.scenes[scene_index])]

--- a/l5kit/l5kit/dataset/ego.py
+++ b/l5kit/l5kit/dataset/ego.py
@@ -96,8 +96,12 @@ None if not desired
                 stacklevel=2,
             )
         data = self.sample_function(state_index, frames, self.dataset.agents, tl_faces, track_id)
-        # 0,1,C -> C,0,1
-        image = data["image"].transpose(2, 0, 1)
+
+        # when rast is None, image could be None
+        image = data["image"]
+        if image is not None:
+            # 0,1,C -> C,0,1
+            image = image.transpose(2, 0, 1)
 
         target_positions = np.array(data["target_positions"], dtype=np.float32)
         target_yaws = np.array(data["target_yaws"], dtype=np.float32)

--- a/l5kit/l5kit/dataset/ego.py
+++ b/l5kit/l5kit/dataset/ego.py
@@ -98,12 +98,6 @@ None if not desired
             )
         data = self.sample_function(state_index, frames, self.dataset.agents, tl_faces, track_id)
 
-        # when rast is None, image could be None
-        image = data["image"]
-        if image is not None:
-            # 0,1,C -> C,0,1
-            image = image.transpose(2, 0, 1)
-
         target_positions = np.array(data["target_positions"], dtype=np.float32)
         target_yaws = np.array(data["target_yaws"], dtype=np.float32)
 
@@ -113,8 +107,7 @@ None if not desired
         timestamp = frames[state_index]["timestamp"]
         track_id = np.int64(-1 if track_id is None else track_id)  # always a number to avoid crashing torch
 
-        return {
-            "image": image,
+        result = {
             "target_positions": target_positions,
             "target_yaws": target_yaws,
             "target_availabilities": data["target_availabilities"],
@@ -132,6 +125,14 @@ None if not desired
             "yaw": data["yaw"],
             "extent": data["extent"],
         }
+
+        # when rast is None, image could be None
+        image = data["image"]
+        if image is not None:
+            # 0,1,C -> C,0,1
+            result["image"] = image.transpose(2, 0, 1)
+
+        return result
 
     def __getitem__(self, index: int) -> dict:
         """

--- a/l5kit/l5kit/tests/dataset/dataset_test.py
+++ b/l5kit/l5kit/tests/dataset/dataset_test.py
@@ -90,5 +90,5 @@ def test_no_rast_dataset(
     indexes = [0, 1, 10, -1]  # because we pad, even the first index should have an (entire black) history
     for idx in indexes:
         data = dataset[idx]
-        assert data["image"] is None
+        assert "image" not in data
     check_torch_loading(dataset)

--- a/l5kit/l5kit/tests/dataset/dataset_test.py
+++ b/l5kit/l5kit/tests/dataset/dataset_test.py
@@ -77,3 +77,17 @@ def test_non_zero_history(
     for idx in indexes:
         data = dataset[idx]
         assert data["image"].shape == (2 * (history_num_frames + 1), *rast_params["raster_size"])
+
+
+@pytest.mark.parametrize("history_num_frames", [1, 2, 3, 4])
+@pytest.mark.parametrize("dataset_cls", [EgoDataset, AgentDataset])
+def test_no_rast_dataset(
+    history_num_frames: int, dataset_cls: Callable, zarr_dataset: ChunkedDataset, dmg: LocalDataManager, cfg: dict
+) -> None:
+    cfg["model_params"]["history_num_frames"] = history_num_frames
+    rasterizer = None
+    dataset = dataset_cls(cfg, zarr_dataset, rasterizer, None)
+    indexes = [0, 1, 10, -1]  # because we pad, even the first index should have an (entire black) history
+    for idx in indexes:
+        data = dataset[idx]
+        assert data["image"] is None

--- a/l5kit/l5kit/tests/dataset/dataset_test.py
+++ b/l5kit/l5kit/tests/dataset/dataset_test.py
@@ -91,3 +91,4 @@ def test_no_rast_dataset(
     for idx in indexes:
         data = dataset[idx]
         assert data["image"] is None
+    check_torch_loading(dataset)


### PR DESCRIPTION
I think currently if you use None rasterizer it'll throw.