### PR TITLE
[AVR-816] Speedup semantic rasteriser

### DIFF
--- a/l5kit/l5kit/rasterization/box_rasterizer.py
+++ b/l5kit/l5kit/rasterization/box_rasterizer.py
@@ -9,7 +9,7 @@ from ..data.filter import filter_agents_by_labels, filter_agents_by_track_id
 from ..geometry import rotation33_as_yaw, transform_points
 from .rasterizer import EGO_EXTENT_HEIGHT, EGO_EXTENT_LENGTH, EGO_EXTENT_WIDTH, Rasterizer
 from .render_context import RenderContext
-from .semantic_rasterizer import CV2_SHIFT, cv2_subpixel
+from .semantic_rasterizer import CV2_SUB_VALUES, cv2_subpixel
 
 
 def get_ego_as_agent(frame: np.ndarray) -> np.ndarray:  # TODO this can be useful to have around
@@ -69,7 +69,7 @@ def draw_boxes(
 
     # fillPoly wants polys in a sequence with points inside as (x,y)
     box_raster_coords = cv2_subpixel(box_raster_coords.reshape((-1, 4, 2)))
-    cv2.fillPoly(im, box_raster_coords, color=color, lineType=cv2.LINE_AA, shift=CV2_SHIFT)
+    cv2.fillPoly(im, box_raster_coords, color=color, **CV2_SUB_VALUES)
     return im
 
 

--- a/l5kit/l5kit/rasterization/semantic_rasterizer.py
+++ b/l5kit/l5kit/rasterization/semantic_rasterizer.py
@@ -125,6 +125,7 @@ class SemanticRasterizer(Rasterizer):
         for idx, lane_idx in enumerate(lane_indices):
             lane_idx = self.mapAPI.bounds_info["lanes"]["ids"][lane_idx]
 
+            # interpolate over polyline to always have the same number of points
             lane_coords = self.mapAPI.get_lane_as_interpolation(
                 lane_idx, INTERPOLATION_POINTS, InterpolationMethod.INTER_ENSURE_LEN
             )

--- a/l5kit/l5kit/rasterization/semantic_rasterizer.py
+++ b/l5kit/l5kit/rasterization/semantic_rasterizer.py
@@ -119,7 +119,7 @@ class SemanticRasterizer(Rasterizer):
         # get all lanes as interpolation so that we can transform them all together
 
         lane_indices = indices_in_bounds(center_in_world, self.mapAPI.bounds_info["lanes"]["bounds"], raster_radius)
-        lanes_lines: Dict[str, np.ndarray] = defaultdict(lambda: np.zeros(len(lane_indices) * 2, dtype=np.bool))
+        lanes_mask: Dict[str, np.ndarray] = defaultdict(lambda: np.zeros(len(lane_indices) * 2, dtype=np.bool))
         lanes_area = np.zeros((len(lane_indices) * 2, INTERPOLATION_POINTS, 2))
 
         for idx, lane_idx in enumerate(lane_indices):
@@ -141,7 +141,7 @@ class SemanticRasterizer(Rasterizer):
                     lane_type = "green"
                 elif self.mapAPI.is_traffic_face_colour(tl_id, "yellow"):
                     lane_type = "yellow"
-            lanes_lines[lane_type][idx * 2 : idx * 2 + 2] = True
+            lanes_mask[lane_type][idx * 2 : idx * 2 + 2] = True
 
         if len(lanes_area):
             lanes_area = cv2_subpixel(transform_points(lanes_area.reshape((-1, 2)), raster_from_world))
@@ -151,10 +151,10 @@ class SemanticRasterizer(Rasterizer):
                 cv2.fillPoly(img, [lane_area], (17, 17, 31), **CV2_SUB_VALUES)
 
             lanes_area = lanes_area.reshape((-1, INTERPOLATION_POINTS, 2))
-            cv2.polylines(img, lanes_area[lanes_lines["default"]], False, (255, 217, 82), **CV2_SUB_VALUES)
-            cv2.polylines(img, lanes_area[lanes_lines["red"]], False, (255, 0, 0), **CV2_SUB_VALUES)
-            cv2.polylines(img, lanes_area[lanes_lines["yellow"]], False, (255, 255, 0), **CV2_SUB_VALUES)
-            cv2.polylines(img, lanes_area[lanes_lines["green"]], False, (0, 255, 0), **CV2_SUB_VALUES)
+            cv2.polylines(img, lanes_area[lanes_mask["default"]], False, (255, 217, 82), **CV2_SUB_VALUES)
+            cv2.polylines(img, lanes_area[lanes_mask["red"]], False, (255, 0, 0), **CV2_SUB_VALUES)
+            cv2.polylines(img, lanes_area[lanes_mask["yellow"]], False, (255, 255, 0), **CV2_SUB_VALUES)
+            cv2.polylines(img, lanes_area[lanes_mask["green"]], False, (0, 255, 0), **CV2_SUB_VALUES)
 
         # plot crosswalks
         crosswalks = []


### PR DESCRIPTION
Speed-up `py_semantic` by using a single `transform_points` though lanes interpolation

In a local test this speeds up rasterisation end-to-end by 2X almost (from 50it/s to 95it/s). Still to confirm how this reflects into training