### PR TITLE
[AVR-835] fix bug in draw arrow matrix

### DIFF
--- a/l5kit/l5kit/tests/visualization/utils_test.py
+++ b/l5kit/l5kit/tests/visualization/utils_test.py
@@ -15,6 +15,15 @@ def test_draw_trajectory() -> None:
     assert np.all(on_image[0, 20] == (0, 0, 0))
     assert np.all(on_image[0, 10] == (0, 0, 0))
 
+    # test also with arrowed lines
+    on_image = np.zeros((224, 244, 3), dtype=np.uint8)
+    yaws = np.asarray([[0.1], [-0.1], [0.0]])
+    draw_trajectory(on_image, positions, (255, 255, 255), yaws=yaws)
+
+    assert np.all(on_image[0, 0] == (255, 255, 255))
+    assert np.all(on_image[10, 0] == (255, 255, 255))
+    assert np.all(on_image[20, 0] == (255, 255, 255))
+
 
 def test_draw_reference_trajectory() -> None:
     on_image = np.zeros((224, 244, 3), dtype=np.uint8)

--- a/l5kit/l5kit/visualization/utils.py
+++ b/l5kit/l5kit/visualization/utils.py
@@ -28,7 +28,8 @@ def draw_arrowed_line(on_image: np.ndarray, position: np.ndarray, yaw: float, rg
     """
     start_pixel = np.array(position[:2])
 
-    rot = cv2.getRotationMatrix2D((0, 0), np.degrees(-yaw), 1.0)  # minus here because of cv2 rotations convention
+    rot = np.eye(3)
+    rot[:-1] = cv2.getRotationMatrix2D((0, 0), np.degrees(-yaw), 1.0)  # minus here because of cv2 rotations convention
     end_pixel = start_pixel + transform_point(np.asarray([ARROW_LENGTH_IN_PIXELS, 0]), rot)
 
     cv2.arrowedLine(


### PR DESCRIPTION
Fix crash because of non-squared matrix with `draw_arrowed_line function`

- [X] Fix matrix shape
- [X] add tests for `draw_arrowed_line`