### PR TITLE
[AVR-837] apply batch transform to sampling

### DIFF
--- a/l5kit/l5kit/sampling/agent_sampling.py
+++ b/l5kit/l5kit/sampling/agent_sampling.py
@@ -157,8 +157,8 @@ def get_relative_poses(
         availabilities[i] = 1.0
 
     # batch transform to speed up
-    positions_m = transform_points(positions_m, agent_from_world) * availabilities[:, None]
-    yaws_rad = angular_distance(yaws_rad, current_agent_yaw) * availabilities[:, None]
+    positions_m = transform_points(positions_m, agent_from_world) * availabilities[:, np.newaxis]
+    yaws_rad = angular_distance(yaws_rad, current_agent_yaw) * availabilities[:, np.newaxis]
     return positions_m.astype(np.float32), yaws_rad, extents_m, availabilities
 
 


### PR DESCRIPTION
Apply batch transform to positions. This saves N-1 transforms call for N future/history frames.

Add a note about the return dtype, as it gets casted from `float64` to float32` inside.
Question: should we cast here or later (provided we need to do it for torch)?