### PR TITLE
[Fix] Satellite Image Transform for Non-Squared Raster

### DIFF
--- a/l5kit/l5kit/rasterization/satellite_image.py
+++ b/l5kit/l5kit/rasterization/satellite_image.py
@@ -63,12 +63,21 @@ def get_sat_image_crop_scaled(
         (np.ndarray): a crop of input ``sat_image``
     """
 
-    crop_size_in_meters = np.array(crop_size) * pixel_size
+    max_crop_size = [max(crop_size), max(crop_size)]
+    crop_size_in_meters = np.array(max_crop_size) * pixel_size
     crop_size_in_sat_pixels = np.int0(np.round(crop_size_in_meters / sat_pixel_scale))
 
     sat_crop = get_sat_image_crop(sat_image, crop_size_in_sat_pixels, sat_pixel_translation, yaw)
 
-    return cv2.resize(sat_crop, tuple(crop_size), interpolation=interpolation)
+    resized_sat_crop = cv2.resize(sat_crop, tuple(max_crop_size), interpolation=interpolation)
+    start_x = np.int0(resized_sat_crop.shape[0] / 2 - crop_size[1] / 2)
+    end_x = start_x + crop_size[1]
+    start_y = np.int0(resized_sat_crop.shape[1] / 2 - crop_size[0] / 2)
+    end_y = start_y + crop_size[0]
+
+    out_sat_crop = resized_sat_crop[start_x:end_x, start_y:end_y]
+
+    return out_sat_crop
 
 
 def get_sat_image_crop(

--- a/l5kit/l5kit/tests/rasterization/satellite_image_test.py
+++ b/l5kit/l5kit/tests/rasterization/satellite_image_test.py
@@ -39,7 +39,7 @@ def test_satellite_image_cropping_rectangular() -> None:
         crop_im = get_sat_image_crop_scaled(
             sat_image, crop_size=(200, 100), sat_pixel_translation=np.array([500, 500]), yaw=yaw
         )
-        assert crop_im.shape == (200, 100, 3)
+        assert crop_im.shape == (100, 200, 3)
 
         assert crop_im[..., 0].mean() == pytest.approx(0.25, 0.1)  # One quarter should still be red
         assert crop_im[..., 1].mean() == pytest.approx(0.25, 0.1)  # One quarter should still be green

--- a/l5kit/l5kit/tests/rasterization/satellite_image_test.py
+++ b/l5kit/l5kit/tests/rasterization/satellite_image_test.py
@@ -5,7 +5,7 @@ import pytest
 from l5kit.rasterization import get_sat_image_crop, get_sat_image_crop_scaled
 
 
-def test_satellite_image_cropping() -> None:
+def test_satellite_image_cropping_square() -> None:
 
     sat_image = np.zeros((1001, 1001, 3), dtype=np.float32)
     sat_image[500:, :500, 0] = 1  # Make top right corner red
@@ -17,6 +17,29 @@ def test_satellite_image_cropping() -> None:
             sat_image, crop_size=(200, 200), sat_pixel_translation=np.array([500, 500]), yaw=yaw
         )
         assert crop_im.shape == (200, 200, 3)
+
+        assert crop_im[..., 0].mean() == pytest.approx(0.25, 0.1)  # One quarter should still be red
+        assert crop_im[..., 1].mean() == pytest.approx(0.25, 0.1)  # One quarter should still be green
+        if yaw == 0.5 * np.pi:
+            # The top left should be blue now
+            np.testing.assert_array_equal(crop_im[0, 0], np.array([0, 0, 1]))
+
+    with pytest.raises(IndexError):
+        get_sat_image_crop_scaled(sat_image, crop_size=(10, 10), sat_pixel_translation=np.array([0, 1000]))
+
+
+def test_satellite_image_cropping_rectangular() -> None:
+
+    sat_image = np.zeros((1001, 1001, 3), dtype=np.float32)
+    sat_image[500:, :500, 0] = 1  # Make top right corner red
+    sat_image[:500, :500, 1] = 1  # Make bottom right corner green
+    sat_image[:500, 500:, 2] = 1  # Make bottom left corner blue
+
+    for yaw in [None, np.pi, 0.5 * np.pi]:
+        crop_im = get_sat_image_crop_scaled(
+            sat_image, crop_size=(200, 100), sat_pixel_translation=np.array([500, 500]), yaw=yaw
+        )
+        assert crop_im.shape == (200, 100, 3)
 
         assert crop_im[..., 0].mean() == pytest.approx(0.25, 0.1)  # One quarter should still be red
         assert crop_im[..., 1].mean() == pytest.approx(0.25, 0.1)  # One quarter should still be green


### PR DESCRIPTION
Non squared raster settings cause a wrong transform in the satellite images.
This patch should fix the issue. 

See the images below.

Before patch:
![old_loader](https://user-images.githubusercontent.com/1069138/103810776-1e453f00-505c-11eb-8998-fe452013ef61.png)

After patch:
![new_loader](https://user-images.githubusercontent.com/1069138/103810784-21402f80-505c-11eb-8079-9b0580566739.png)
