### PR TITLE
Fixing the issue with the norm over heights

### DIFF
--- a/l5kit/l5kit/planning/utils.py
+++ b/l5kit/l5kit/planning/utils.py
@@ -67,6 +67,6 @@ def within_range(ego_centroid: np.ndarray, ego_extent: np.ndarray,
     """
     distance = np.linalg.norm(ego_centroid - agent_centroid, axis=-1)
     norm_ego = np.linalg.norm(ego_extent[:2])
-    norm_agent = np.linalg.norm(agent_extent[:, 2], axis=-1)
+    norm_agent = np.linalg.norm(agent_extent[:, :2], axis=-1)
     max_range = 0.5 * (norm_ego + norm_agent)
     return distance < max_range


### PR DESCRIPTION
Fix for the within range function used by the collision detection metric (norm was being calculated over heights of agents).