### PR TITLE
Return `recent_speed` when possible.

### DIFF
--- a/l5kit/l5kit/sampling/agent_sampling.py
+++ b/l5kit/l5kit/sampling/agent_sampling.py
@@ -258,7 +258,7 @@ def generate_agent_sample(
 
     history_vels_mps, future_vels_mps = compute_agent_velocity(history_positions_m, future_positions_m, step_time)
 
-    return {
+    result = {
         "frame_index": state_index,
         "image": input_im,
         "target_positions": future_positions_m,
@@ -276,8 +276,10 @@ def generate_agent_sample(
         "world_from_agent": world_from_agent,
         "centroid": agent_centroid_m,
         "yaw": agent_yaw_rad,
-        "speed": np.linalg.norm(future_vels_mps[0]),
         "extent": agent_extent_m,
         "history_extents": history_extents,
         "future_extents": future_extents,
     }
+    if len(history_vels_mps) > 0:
+        result["history_speed"] = np.linalg.norm(history_vels_mps[0])
+    return result

--- a/l5kit/l5kit/sampling/agent_sampling.py
+++ b/l5kit/l5kit/sampling/agent_sampling.py
@@ -281,5 +281,5 @@ def generate_agent_sample(
         "future_extents": future_extents,
     }
     if len(history_vels_mps) > 0:
-        result["history_speed"] = np.linalg.norm(history_vels_mps[0])
+        result["recent_speed"] = np.linalg.norm(history_vels_mps[0])
     return result


### PR DESCRIPTION
Context: the `speed` parameter contained information about the future, thus allowing them to leak to the model. I substitute it with the history speed, which can be computed when history is given.