### PR TITLE
Move scene dataset creation to zarr

### DIFF
--- a/l5kit/l5kit/data/zarr_dataset.py
+++ b/l5kit/l5kit/data/zarr_dataset.py
@@ -5,6 +5,7 @@ import numpy as np
 import zarr
 from prettytable import PrettyTable
 
+from .filter import get_agents_slice_from_frames, get_frames_slice_from_scenes, get_tl_faces_slice_from_frames
 from .labels import PERCEPTION_LABELS, TL_FACE_LABELS
 
 
@@ -198,3 +199,36 @@ opened.
         table.float_format = ".2"
         table.add_row(values)
         return str(table)
+
+    def get_scene_dataset(self, scene_index: int) -> "ChunkedDataset":
+        """
+        Get a new ChunkedDataset of a single scene. This dataset lives in memory (as np.ndarray)
+        Args:
+            scene_index (int): the scene index
+
+        Returns:
+            ChunkedDataset: the scene dataset
+        """
+        if scene_index >= len(self.scenes):
+            raise ValueError(f"scene index {scene_index} out of bound for dataset with {len(self.scenes)} scenes")
+
+        scenes = self.scenes[scene_index: scene_index + 1].copy()
+        frame_slice = get_frames_slice_from_scenes(*scenes)
+        frames = self.frames[frame_slice].copy()
+        agent_slice = get_agents_slice_from_frames(*frames[[0, -1]])
+        tl_slice = get_tl_faces_slice_from_frames(*frames[[0, -1]])
+
+        agents = self.agents[agent_slice].copy()
+        tl_faces = self.tl_faces[tl_slice].copy()
+
+        frames["agent_index_interval"] -= agent_slice.start
+        frames["traffic_light_faces_index_interval"] -= tl_slice.start
+        scenes["frame_index_interval"] -= frame_slice.start
+
+        dataset = ChunkedDataset("")
+        dataset.agents = agents
+        dataset.tl_faces = tl_faces
+        dataset.frames = frames
+        dataset.scenes = scenes
+
+        return dataset

--- a/l5kit/l5kit/data/zarr_dataset.py
+++ b/l5kit/l5kit/data/zarr_dataset.py
@@ -201,13 +201,11 @@ opened.
         return str(table)
 
     def get_scene_dataset(self, scene_index: int) -> "ChunkedDataset":
-        """
-        Get a new ChunkedDataset of a single scene. This dataset lives in memory (as np.ndarray)
-        Args:
-            scene_index (int): the scene index
+        """Get a new ChunkedDataset of a single scene.
+        This dataset lives in memory (as np.ndarray)
 
-        Returns:
-            ChunkedDataset: the scene dataset
+        :param scene_index: the scene index
+        :return: a dataset with a single scene inside
         """
         if scene_index >= len(self.scenes):
             raise ValueError(f"scene index {scene_index} out of bound for dataset with {len(self.scenes)} scenes")

--- a/l5kit/l5kit/dataset/ego.py
+++ b/l5kit/l5kit/dataset/ego.py
@@ -144,7 +144,6 @@ None if not desired
             EgoDataset: A valid EgoDataset dataset with a copy of the data
 
         """
-        # copy everything to avoid references (scene is already detached from zarr if get_combined_scene was called)
         dataset = self.dataset.get_scene_dataset(scene_index)
         return EgoDataset(self.cfg, dataset, self.rasterizer, self.perturbation)
 

--- a/l5kit/l5kit/dataset/ego.py
+++ b/l5kit/l5kit/dataset/ego.py
@@ -6,8 +6,7 @@ from typing import Optional
 import numpy as np
 from torch.utils.data import Dataset
 
-from ..data import (ChunkedDataset, get_agents_slice_from_frames, get_frames_slice_from_scenes,
-                    get_tl_faces_slice_from_frames)
+from ..data import ChunkedDataset, get_frames_slice_from_scenes
 from ..kinematic import Perturbation
 from ..rasterization import Rasterizer, RenderContext
 from ..sampling import generate_agent_sample
@@ -146,25 +145,7 @@ None if not desired
 
         """
         # copy everything to avoid references (scene is already detached from zarr if get_combined_scene was called)
-        scenes = self.dataset.scenes[scene_index: scene_index + 1].copy()
-        frame_slice = get_frames_slice_from_scenes(*scenes)
-        frames = self.dataset.frames[frame_slice].copy()
-        agent_slice = get_agents_slice_from_frames(*frames[[0, -1]])
-        tl_slice = get_tl_faces_slice_from_frames(*frames[[0, -1]])
-
-        agents = self.dataset.agents[agent_slice].copy()
-        tl_faces = self.dataset.tl_faces[tl_slice].copy()
-
-        frames["agent_index_interval"] -= agent_slice.start
-        frames["traffic_light_faces_index_interval"] -= tl_slice.start
-        scenes["frame_index_interval"] -= frame_slice.start
-
-        dataset = ChunkedDataset("")
-        dataset.agents = agents
-        dataset.tl_faces = tl_faces
-        dataset.frames = frames
-        dataset.scenes = scenes
-
+        dataset = self.dataset.get_scene_dataset(scene_index)
         return EgoDataset(self.cfg, dataset, self.rasterizer, self.perturbation)
 
     def get_scene_indices(self, scene_idx: int) -> np.ndarray:

--- a/l5kit/l5kit/tests/data/zarr_dataset_test.py
+++ b/l5kit/l5kit/tests/data/zarr_dataset_test.py
@@ -1,6 +1,11 @@
-import numpy as np
+from pathlib import Path
+from uuid import uuid4
 
-from l5kit.data import ChunkedDataset
+import numpy as np
+import pytest
+
+from l5kit.data import ChunkedDataset, LocalDataManager
+from l5kit.data.zarr_utils import zarr_concat
 
 
 def test_load_dataset(zarr_dataset: ChunkedDataset) -> None:
@@ -14,3 +19,24 @@ def test_load_dataset(zarr_dataset: ChunkedDataset) -> None:
 
     # check positions differ
     assert np.any(zarr_dataset.frames[0]["ego_translation"] != zarr_dataset.frames[1]["ego_translation"])
+
+
+def test_get_scene_dataset(dmg: LocalDataManager, tmp_path: Path, zarr_dataset: ChunkedDataset) -> None:
+    concat_count = 4
+    zarr_input_path = dmg.require("single_scene.zarr")
+    zarr_output_path = str(tmp_path / f"{uuid4()}.zarr")
+
+    zarr_concat([zarr_input_path] * concat_count, zarr_output_path)
+    zarr_cat_dataset = ChunkedDataset(zarr_output_path)
+    zarr_cat_dataset.open()
+
+    # all scenes should be the same as the input one
+    for scene_idx in range(concat_count):
+        zarr_scene = zarr_cat_dataset.get_scene_dataset(scene_idx)
+        assert np.alltrue(zarr_scene.scenes == np.asarray(zarr_dataset.scenes))
+        assert np.alltrue(zarr_scene.frames == np.asarray(zarr_dataset.frames))
+        assert np.alltrue(zarr_scene.agents == np.asarray(zarr_dataset.agents))
+        assert np.alltrue(zarr_scene.tl_faces == np.asarray(zarr_dataset.tl_faces))
+
+    with pytest.raises(ValueError):
+        zarr_cat_dataset.get_scene_dataset(concat_count + 1)


### PR DESCRIPTION
Allow to get a scene dataset from `ChunkedDataset` only. This reduces dependencies on `EgoDataset`.
Add also a test for the new function