### PR TITLE
Adding distance to reference trajectory closed-loop metric

### DIFF
--- a/l5kit/l5kit/cle/metrics.py
+++ b/l5kit/l5kit/cle/metrics.py
@@ -68,7 +68,7 @@ class DisplacementErrorL2Metric(DisplacementErrorMetric):
         super().__init__(error_functions.l2_error)
 
 
-class DistanceToRefTrajectoryMetric:
+class DistanceToRefTrajectoryMetric(SupportsMetricCompute):
     """Distance to reference trajectory metric. This metric will compute
     the distance from the predicted centroid to the closest waypoint
     in the reference trajectory.

--- a/l5kit/l5kit/cle/metrics.py
+++ b/l5kit/l5kit/cle/metrics.py
@@ -4,6 +4,7 @@ import torch
 from typing_extensions import Protocol
 
 from l5kit.evaluation import error_functions
+from l5kit.evaluation import metrics as l5metrics
 
 
 # TODO(perone): mocking the output for now
@@ -65,3 +66,50 @@ class DisplacementErrorL2Metric(DisplacementErrorMetric):
 
     def __init__(self) -> None:
         super().__init__(error_functions.l2_error)
+
+
+class DistanceToRefTrajectoryMetric:
+    """Distance to reference trajectory metric. This metric will compute
+    the distance from the predicted centroid to the closest waypoint
+    in the reference trajectory.
+
+    .. note::  Please note that this metric is different than the displacement
+               error because it is taking into consideration the entire
+               reference trajectory at each point of the simulated trajectory.
+
+    :param scene_fraction: fraction of the simulated scene used to
+                           evaluate against the reference trajectory. This
+                           fraction should be between 0.0 and 1.0.
+    """
+    metric_name = "distance_to_reference_trajectory"
+
+    def __init__(self, scene_fraction: float = 0.8) -> None:
+        # Check fraction range
+        if scene_fraction < 0.0 or scene_fraction > 1.0:
+            raise ValueError("'screne_fraction' should be between 0.0 and 1.0.")
+
+        self.scene_fraction = scene_fraction
+
+    def compute(self, simulation_output: SimulationOutput) -> torch.Tensor:
+        """Compute the metric on all frames of the scene.
+
+        :param simulation_output: the output from the closed-loop simulation
+        :returns: distance to reference trajectory per
+                  frame [Shape: N, where N = timesteps]
+        """
+        # Shape = [Timesteps, 7]
+        simulated_scene_ego_state = simulation_output.simulated_ego_states
+        simulated_centroid = simulated_scene_ego_state[:, :2]  # [Timesteps, 2]
+        observed_ego_states = simulation_output.recorded_ego_states[:, :2]
+
+        if len(observed_ego_states) < len(simulated_centroid):
+            raise ValueError("More simulated timesteps than observed.")
+
+        # Trim the simulated trajectory to have a specified fraction
+        simulated_fraction_length = int(len(simulated_centroid) * self.scene_fraction)
+        simulated_centroid_fraction = simulated_centroid[0:simulated_fraction_length]
+
+        observed_ego_states = observed_ego_states.unsqueeze(0)
+        distance = l5metrics.distance_to_reference_trajectory(simulated_centroid_fraction,
+                                                              observed_ego_states)
+        return distance

--- a/l5kit/l5kit/tests/cle/test_metrics.py
+++ b/l5kit/l5kit/tests/cle/test_metrics.py
@@ -87,3 +87,113 @@ class TestDisplacementErrorMetric(unittest.TestCase):
         metric = metrics.DisplacementErrorMetric(error_functions.l2_error)
         with self.assertRaisesRegex(ValueError, "More simulated timesteps than observed"):
             _ = metric.compute(sim_output)
+
+
+class TestDistanceToRefTrajectory(unittest.TestCase):
+    def test_same_trajectory(self) -> None:
+        attrs = {
+            "simulated_ego_states": torch.ones(20, 7),
+            "recorded_ego_states": torch.ones(20, 7),
+        }
+        sim_output = mock.Mock(**attrs)
+        metric = metrics.DistanceToRefTrajectoryMetric()
+        result = metric.compute(sim_output)
+        self.assertEqual(result.sum(), 0.)
+
+    def test_different_fraction(self) -> None:
+        simulated_steps = 20
+        scene_fraction = 0.5
+        attrs = {
+            "simulated_ego_states": torch.ones(simulated_steps, 7),
+            "recorded_ego_states": torch.ones(simulated_steps, 7),
+        }
+        sim_output = mock.Mock(**attrs)
+        metric = metrics.DistanceToRefTrajectoryMetric(scene_fraction)
+        result = metric.compute(sim_output)
+
+        simulated_steps_fraction = int(simulated_steps * scene_fraction)
+        self.assertEqual(len(result), simulated_steps_fraction)
+        self.assertEqual(result.sum(), 0.)
+
+    def test_symmetry(self) -> None:
+        attrs = {
+            "simulated_ego_states": torch.ones(20, 7),
+            "recorded_ego_states": torch.full((20, 7), 2.0),
+        }
+        sim_output = mock.Mock(**attrs)
+        metric = metrics.DistanceToRefTrajectoryMetric()
+        result = metric.compute(sim_output)
+
+        attrs = {
+            "simulated_ego_states": torch.full((20, 7), 2.0),
+            "recorded_ego_states": torch.ones(20, 7),
+        }
+        sim_output = mock.Mock(**attrs)
+        metric = metrics.DistanceToRefTrajectoryMetric()
+        result_switch = metric.compute(sim_output)
+        self.assertEqual(result.sum(), result_switch.sum())
+
+    def test_parallel_trajectory(self) -> None:
+        simulated_steps = 20
+        attrs = {
+            "simulated_ego_states": torch.ones(simulated_steps, 7),
+            "recorded_ego_states": torch.full((20, 7), 2.0),
+        }
+        sim_output = mock.Mock(**attrs)
+        metric = metrics.DistanceToRefTrajectoryMetric()
+        result = metric.compute(sim_output)
+
+        # Default fraction should be 80% of the samples
+        simulated_steps_fraction = int(simulated_steps * 0.8)
+        self.assertEqual(len(result), simulated_steps_fraction)
+        self.assertEqual(len(torch.unique(result)), 1)
+        self.assertAlmostEqual(torch.unique(result).item(), 1.4142, 4)
+
+    def test_larger_observed_ego(self) -> None:
+        simulated_steps = 20
+        attrs = {
+            "simulated_ego_states": torch.ones(simulated_steps, 7),
+            "recorded_ego_states": torch.ones(50, 7),
+        }
+        sim_output = mock.Mock(**attrs)
+        metric = metrics.DistanceToRefTrajectoryMetric()
+        result = metric.compute(sim_output)
+        self.assertEqual(result.sum(), 0.)
+
+        # Default fraction should be 80% of the samples
+        simulated_steps_fraction = int(simulated_steps * 0.8)
+        self.assertEqual(len(result), simulated_steps_fraction)
+
+    def test_larger_simulated_ego(self) -> None:
+        attrs = {
+            "simulated_ego_states": torch.ones(50, 7),
+            "recorded_ego_states": torch.ones(20, 7),
+        }
+        sim_output = mock.Mock(**attrs)
+        metric = metrics.DistanceToRefTrajectoryMetric()
+
+        with self.assertRaisesRegex(ValueError, "More simulated timesteps than observed"):
+            _ = metric.compute(sim_output)
+
+    def test_half_trajectories(self) -> None:
+        observed_trajectory = torch.ones(40, 7)
+        observed_trajectory[20:, :] += 1.0
+        attrs = {
+            "simulated_ego_states": torch.ones(40, 7),
+            "recorded_ego_states": observed_trajectory,
+        }
+        sim_output = mock.Mock(**attrs)
+        metric = metrics.DistanceToRefTrajectoryMetric()
+        result = metric.compute(sim_output)
+        self.assertEqual(len(torch.unique(result)), 1)
+
+    def test_more_simulation_than_observation(self) -> None:
+        timesteps = 20
+        attrs = {
+            "simulated_ego_states": torch.ones(timesteps + 20, 7),
+            "recorded_ego_states": torch.ones(timesteps, 7),
+        }
+        sim_output = mock.Mock(**attrs)
+        metric = metrics.DistanceToRefTrajectoryMetric()
+        with self.assertRaisesRegex(ValueError, "More simulated timesteps than observed"):
+            _ = metric.compute(sim_output)


### PR DESCRIPTION
Changes in this PR:

- Adds the `DistanceToRefTrajectoryMetric` metric
- Adds unit-testing for the new metric