### PR TITLE
[AVR-975] Fix SimulationOutput

### DIFF
--- a/l5kit/l5kit/simulation/unroll.py
+++ b/l5kit/l5kit/simulation/unroll.py
@@ -70,7 +70,7 @@ class SimulationOutput:
         :param frames: the scene frames
         :return: the trajectory
         """
-        trajectory_states = torch.zeros(len(frames), len(TrajectoryStateIndices.__members__), dtype=torch.float)
+        trajectory_states = torch.zeros(len(frames), len(TrajectoryStateIndices), dtype=torch.float)
         translations = frames["ego_translation"]
         rotations = frames["ego_rotation"]
 


### PR DESCRIPTION
add torch states to `SimulationOutput` which will be used by the evaluation plan. 
Add test for that

NOTE: there is a conversion from float64 to float32 which reduces precision for the torch states