### PR TITLE
adding validators, metrics and composite metrics.

### DIFF
--- a/l5kit/l5kit/cle/composite_metrics.py
+++ b/l5kit/l5kit/cle/composite_metrics.py
@@ -1,10 +1,11 @@
 from abc import abstractmethod
-from typing import Dict, List
+from typing import Dict, List, Type
 
 import torch
 from typing_extensions import Protocol
 
-from l5kit.cle import validators
+from l5kit.cle import metrics, validators
+from l5kit.cle.metrics import SupportsMetricCompute
 from l5kit.simulation.unroll import SimulationOutput
 
 
@@ -32,3 +33,100 @@ class SupportsCompositeMetricCompute(Protocol):
         :returns: a float result
         """
         raise NotImplementedError
+
+
+class PassedDrivenMilesCompositeMetric(SupportsCompositeMetricCompute):
+    """This composite metric will compute the "passed driven miles", which
+    represents the sum of driven miles up to a first intervention frame
+    that is detected based on the list of specified validators.
+
+    :param intervention_validators: an intervention is a defined by any
+                                    failed frame from any of the specified
+                                    validators.
+    :param driven_miles_metric: the metric that should be used as driven
+                                miles (defaults to simulated driven miles),
+                                but can also use the driven miles by the
+                                log replay.
+    :param ignore_entire_scene: if the entire driven miles from the scene
+                                should be ignored when there was an intervention.
+    """
+    #: Name of the composite metric
+    composite_metric_name: str
+    #: List of names for metrics this composite metric depends on
+    requires_metric: List[str]
+    #: List of validators that this composite metric depends on
+    requires_validator: List[str]
+
+    def __init__(self, composite_metric_name: str,
+                 intervention_validators: List[str],
+                 driven_miles_metric: Type[SupportsMetricCompute] =
+                 metrics.SimulatedDrivenMilesMetric,
+                 ignore_entire_scene: bool = False):
+        self.composite_metric_name = composite_metric_name
+        self.requires_metric = [driven_miles_metric.metric_name]
+        self.requires_validator = list(set(intervention_validators))
+        self.ignore_entire_scene = ignore_entire_scene
+
+    def compute(self, metric_results: Dict[str, torch.Tensor],
+                validation_results: Dict[str, validators.ValidatorOutput],
+                simulation_output: SimulationOutput) -> float:
+        """Computes the driven miles until the first intervention
+        is found (first failed frame).
+
+        :param metric_results: results of the metrics required
+        :tensor metric_results: [N], where N is the number of frames in the scene
+        :param validation_results: results from the validators required
+        :param simulation_output: output from the closed-loop simulator
+        :returns: passed driven miles
+        """
+        driven_miles_result = metric_results[self.requires_metric[0]]
+
+        min_all_frame_failed: List[int] = [driven_miles_result.size(0)]
+        for validator_name in self.requires_validator:
+            validator_results = validation_results[validator_name]
+            if len(validator_results.failed_frames) > 0:
+                # If ignore the entire scene is enabled, we just
+                # return 0 passed miles
+                if self.ignore_entire_scene:
+                    return 0.0
+
+                # ... otherwise, we check for the minimum failed
+                # frame to compute the proportional driven miles
+                min_frame_failed = min(validator_results.failed_frames)
+                min_all_frame_failed.append(min_frame_failed)
+
+        min_frame_failed = min(min_all_frame_failed)
+        passed_driven_miles = driven_miles_result[:min_frame_failed].sum()
+        passed_driven_miles_cpu = passed_driven_miles.cpu().item()
+        return float(passed_driven_miles_cpu)
+
+
+class DrivenMilesCompositeMetric(SupportsCompositeMetricCompute):
+    """Composite metric to accumulate the total driven miles.
+
+    :param composite_metric_name: name of the composite metric
+    :param driven_miles_metric: the metric that should be used
+                                to accumulate its values, defaults
+                                to the simulated driven miles
+    """
+    #: Name of the composite metric
+    composite_metric_name: str
+    #: List of names for metrics this composite metric depends on
+    requires_metric: List[str]
+    #: List of validators that this composite metric depends on
+    requires_validator: List[str]
+
+    def __init__(self, composite_metric_name: str,
+                 driven_miles_metric: Type[SupportsMetricCompute] =
+                 metrics.SimulatedDrivenMilesMetric):
+        self.composite_metric_name = composite_metric_name
+        self.driven_miles_metric_name = driven_miles_metric.metric_name
+        self.requires_metric = [self.driven_miles_metric_name]
+        self.requires_validator = []
+
+    def compute(self, metric_results: Dict[str, torch.Tensor],
+                validation_results: Dict[str, validators.ValidatorOutput],
+                simulation_output: SimulationOutput) -> float:
+        driven_miles = metric_results[self.driven_miles_metric_name].sum()
+        driven_miles_cpu = driven_miles.cpu().item()
+        return float(driven_miles_cpu)

--- a/l5kit/l5kit/cle/validators.py
+++ b/l5kit/l5kit/cle/validators.py
@@ -1,10 +1,12 @@
 from abc import abstractmethod
-from typing import Dict, List, NamedTuple
+from enum import IntEnum
+from typing import Dict, List, NamedTuple, Optional, Type
 
 import torch
 from typing_extensions import Protocol
 
-from l5kit.simulation.unroll import SimulationOutput
+from l5kit.cle import metrics
+from l5kit.simulation.unroll import SimulationOutput, TrajectoryStateIndices
 
 
 class ValidatorOutput(NamedTuple):
@@ -36,3 +38,136 @@ class SupportsMetricValidate(Protocol):
         :returns: True if validator passed, False otherwise
         """
         raise NotImplementedError
+
+
+class DurationMode(IntEnum):
+    """For more information about duration mode, see RangeValidator docs."""
+    TOTAL = 0
+    CONTINUOUS = 1
+
+
+class RangeValidator(SupportsMetricValidate):
+    """Validates a metric based on specified range. The range validator will
+    check: min_value < metric_value < max_value. It will also check if the
+    metric violated a maximum duration (see duration_mode parameter notes).
+
+    :param validator_name: name of the validator
+    :param metric: metric class used to validate
+    :param min_value: minimum value allowed (inclusive)
+    :param max_value: maximum value allowed (inclusive)
+    :param violation_duration_s: maximum allowed duration in seconds
+                                 where the metric can be violated
+    :param duration_mode: the duration mode can be "total" or "continuous". In
+                          "total" mode, all violations are summed per scene, and
+                          if they exceed the violation_duration_s parameter, then
+                          it will not pass the validation. In "continuous" mode,
+                          the violation_duration_s parameter must be exceded
+                          on a continuous violation of the metric in time (without
+                          a gap of non-violation). This parameter is ignored
+                          if violation_duration_s is zero.
+    """
+
+    def __init__(self, validator_name: str, metric: Type[metrics.SupportsMetricCompute],
+                 min_value: Optional[float] = None, max_value: Optional[float] = None,
+                 violation_duration_s: float = 0.0, duration_mode: DurationMode = DurationMode.TOTAL):
+        # Requires at least one value specification
+        if min_value is None and max_value is None:
+            raise ValueError("At least one parameter must be "
+                             "specified: min_value or max_value.")
+
+        if min_value is not None and max_value is not None:
+            if min_value >= max_value:
+                raise ValueError("Minimum value cannot be greater or equal"
+                                 " to the maximum value.")
+
+        self.validator_name = validator_name
+        self.metric_name = metric.metric_name
+        self.requires_metric = [self.metric_name]
+        self.min_value = min_value
+        self.max_value = max_value
+        self.validation_duration_s = violation_duration_s
+        self.duration_mode = duration_mode
+
+    @staticmethod
+    def cumsum_with_reset(timestamp_diff: torch.Tensor,
+                          validation_mask: torch.Tensor) -> torch.Tensor:
+        """Cumulative sum (cumsum) that takes into consideration a valid mask.
+        If the valid mask is False on a timestamp, it will reset the accumulator.
+
+        :param timestamp_diff: timestamps differentiated (1D array)
+        :param validation_mask: a boolean mask with valid/invalid timestamps (1D array)
+        :return: cumulative sum (1D array)
+        """
+        cumsum = torch.zeros_like(timestamp_diff)
+        accumulator = 0.0
+        for idx, (ts, vmask) in enumerate(zip(timestamp_diff, validation_mask)):
+            if not vmask:
+                accumulator = 0.0
+            else:
+                accumulator += ts.item()
+            cumsum[idx] = accumulator
+        return cumsum
+
+    def validate(self, metric_results: Dict[str, torch.Tensor],
+                 simulation_output: SimulationOutput) -> ValidatorOutput:
+        """Apply the validator on the results of the metric computation.
+
+        :param metric_results: all metric results
+        :param simulation_output: output from the closed-loop simulator
+        :returns: True if validator passed, False otherwise
+        """
+        result = metric_results[self.metric_name]
+        validation_mask = torch.zeros_like(result, dtype=torch.bool)
+
+        if self.min_value is not None:
+            validation_mask |= result < self.min_value
+
+        if self.max_value is not None:
+            validation_mask |= result > self.max_value
+
+        # Immediate failure if there is a violation and the allowed
+        # duration is zero
+        if self.validation_duration_s <= 0.0:
+            # Log the failed frames into the scene tracker
+            failed_frame_indexes = torch.nonzero(validation_mask).squeeze(1)
+
+            failed_frame_indexes = failed_frame_indexes.cpu().numpy().tolist()
+
+            is_valid_scene = len(failed_frame_indexes) == 0
+            return ValidatorOutput(is_valid_scene, failed_frame_indexes)
+
+        # If duration is greater than zero, then we check
+        # if there was a violation greater than the
+        # allowed duration
+        ego_states = simulation_output.simulated_ego_states
+        timestamps = ego_states[:, TrajectoryStateIndices.TIME.value]
+
+        # Diff of the timestamps
+        pad = torch.as_tensor([0], device=timestamps.device)
+        pad_ts = torch.cat((pad, timestamps))
+        ts_diff = pad_ts[1:] - pad_ts[:-1]
+
+        # Total mode: we sum all violation durations
+        if self.duration_mode == DurationMode.TOTAL:
+            # Build a cumulative sum (masked by the validation mask)
+            ts_valid_cumsum = (ts_diff * validation_mask).cumsum(dim=0)
+            ts_valid_cumsum = ts_valid_cumsum * validation_mask
+
+        # Continuous mode: we check if any of the durations
+        # violated the constraint
+        if self.duration_mode == DurationMode.CONTINUOUS:
+            # Cumulative sum here is computed with reset, if there is a valid
+            # metric computation between two consecutive chunks of invalid
+            # metrics, then this valid frame will reset the cumulative sum
+            # of the timestamp diffs
+            ts_valid_cumsum = RangeValidator.cumsum_with_reset(ts_diff, validation_mask)
+
+        # Check which timestamps violated the duration
+        ts_cumsum_violated = ts_valid_cumsum > self.validation_duration_s
+
+        # Get the frame indexes and track them
+        violation_indexes = torch.nonzero(ts_cumsum_violated).squeeze(1)
+        violation_indexes = violation_indexes.cpu().numpy().tolist()
+
+        is_valid_scene = len(violation_indexes) == 0
+        return ValidatorOutput(is_valid_scene, violation_indexes)

--- a/l5kit/l5kit/tests/cle/test_composite_metrics.py
+++ b/l5kit/l5kit/tests/cle/test_composite_metrics.py
@@ -1,0 +1,133 @@
+import unittest
+from typing import Dict
+from unittest import mock
+
+import torch
+
+from l5kit.cle import composite_metrics as cm
+from l5kit.cle import metrics, validators
+
+
+class TestPassedDrivenMilesCompositeMetric(unittest.TestCase):
+    def test_failed_frames(self) -> None:
+        validation_results: Dict[str, validators.ValidatorOutput] = {
+            "validator_a": validators.ValidatorOutput(is_valid_scene=False,
+                                                      failed_frames=[15])
+        }
+        metric_results: Dict[str, torch.Tensor] = {
+            metrics.SimulatedDrivenMilesMetric.metric_name: torch.ones(20),
+        }
+        simulation_output = mock.Mock()
+        pdm_metric = cm.PassedDrivenMilesCompositeMetric("passed_driven_miles",
+                                                         ["validator_a"])
+        result = pdm_metric.compute(metric_results, validation_results, simulation_output)
+        simulation_output.assert_not_called()
+        self.assertEqual(result, 15.0)
+
+    def test_failed_frames_multiple_interventions(self) -> None:
+        validation_results: Dict[str, validators.ValidatorOutput] = {
+            "validator_a": validators.ValidatorOutput(is_valid_scene=False,
+                                                      failed_frames=[10, 11]),
+            "validator_b": validators.ValidatorOutput(is_valid_scene=False,
+                                                      failed_frames=[15]),
+            "validator_c": validators.ValidatorOutput(is_valid_scene=False,
+                                                      failed_frames=[15, 18]),
+            "validator_d": validators.ValidatorOutput(is_valid_scene=True,
+                                                      failed_frames=[])
+        }
+        metric_results: Dict[str, torch.Tensor] = {
+            metrics.SimulatedDrivenMilesMetric.metric_name: torch.ones(20),
+        }
+        simulation_output = mock.Mock()
+        pdm_metric = cm.PassedDrivenMilesCompositeMetric("passed_driven_miles",
+                                                         ["validator_a",
+                                                          "validator_b",
+                                                          "validator_c",
+                                                          "validator_d"])
+        result = pdm_metric.compute(metric_results, validation_results, simulation_output)
+        simulation_output.assert_not_called()
+        self.assertEqual(result, 10.0)
+
+    def test_no_failed_frames(self) -> None:
+        validation_results: Dict[str, validators.ValidatorOutput] = {
+            "validator_a": validators.ValidatorOutput(is_valid_scene=True,
+                                                      failed_frames=[])
+        }
+        metric_results: Dict[str, torch.Tensor] = {
+            metrics.SimulatedDrivenMilesMetric.metric_name: torch.ones(20),
+        }
+        simulation_output = mock.Mock()
+        pdm_metric = cm.PassedDrivenMilesCompositeMetric("passed_driven_miles",
+                                                         ["validator_a"])
+        result = pdm_metric.compute(metric_results, validation_results, simulation_output)
+        simulation_output.assert_not_called()
+        self.assertEqual(result, 20.0)
+
+    def test_all_failed_frames(self) -> None:
+        timesteps = 20
+        validation_results: Dict[str, validators.ValidatorOutput] = {
+            "validator_a": validators.ValidatorOutput(is_valid_scene=True,
+                                                      failed_frames=list(range(timesteps)))
+        }
+        metric_results: Dict[str, torch.Tensor] = {
+            metrics.SimulatedDrivenMilesMetric.metric_name: torch.ones(timesteps),
+        }
+        simulation_output = mock.Mock()
+        pdm_metric = cm.PassedDrivenMilesCompositeMetric("passed_driven_miles",
+                                                         ["validator_a"])
+        result = pdm_metric.compute(metric_results, validation_results, simulation_output)
+        simulation_output.assert_not_called()
+        self.assertEqual(result, 0.0)
+
+    def test_ignore_entire_scene(self) -> None:
+        validation_results: Dict[str, validators.ValidatorOutput] = {
+            "validator_a": validators.ValidatorOutput(is_valid_scene=False,
+                                                      failed_frames=[15])
+        }
+        metric_results: Dict[str, torch.Tensor] = {
+            metrics.SimulatedDrivenMilesMetric.metric_name: torch.ones(20),
+        }
+        simulation_output = mock.Mock()
+        pdm_metric = cm.PassedDrivenMilesCompositeMetric("passed_driven_miles",
+                                                         ["validator_a"],
+                                                         ignore_entire_scene=True)
+        result = pdm_metric.compute(metric_results, validation_results, simulation_output)
+        self.assertEqual(result, 0.0)
+
+
+class TestDrivenMilesCompositeMetric(unittest.TestCase):
+    def test_zero_miles(self) -> None:
+        metric_results: Dict[str, torch.Tensor] = {
+            metrics.SimulatedDrivenMilesMetric.metric_name: torch.zeros(10),
+        }
+        simulation_output = mock.Mock()
+        validation_results = mock.Mock()
+        dm_metric = cm.DrivenMilesCompositeMetric("total_driven_miles")
+        result = dm_metric.compute(metric_results, validation_results, simulation_output)
+        simulation_output.assert_not_called()
+        validation_results.assert_not_called()
+        self.assertEqual(result, 0.0)
+
+    def test_driven_miles(self) -> None:
+        # Just ones
+        driven_tensor_ones = torch.ones(10)
+        metric_results: Dict[str, torch.Tensor] = {
+            metrics.SimulatedDrivenMilesMetric.metric_name: driven_tensor_ones,
+        }
+        simulation_output = mock.Mock()
+        validation_results = mock.Mock()
+        dm_metric = cm.DrivenMilesCompositeMetric("total_driven_miles")
+        result = dm_metric.compute(metric_results, validation_results, simulation_output)
+        simulation_output.assert_not_called()
+        validation_results.assert_not_called()
+        self.assertEqual(result, driven_tensor_ones.sum())
+
+        # Different driven mile each step
+        driven_tensor_monotonic = torch.arange(10)
+        metric_results[metrics.SimulatedDrivenMilesMetric.metric_name] = driven_tensor_monotonic
+        simulation_output.reset_mock()
+        validation_results.reset_mock()
+        result = dm_metric.compute(metric_results, validation_results, simulation_output)
+        simulation_output.assert_not_called()
+        validation_results.assert_not_called()
+        self.assertEqual(result, driven_tensor_monotonic.sum())

--- a/l5kit/l5kit/tests/cle/test_validators.py
+++ b/l5kit/l5kit/tests/cle/test_validators.py
@@ -1,0 +1,38 @@
+import unittest
+
+import torch
+
+from l5kit.cle import validators
+
+
+class TestRangeValidator(unittest.TestCase):
+    def test_cumsum_with_reset(self) -> None:
+        ts_diff = torch.full((20,), 0.1, dtype=torch.float32)
+        validation_mask = torch.zeros(20, dtype=torch.bool)
+        validation_mask[0:8] = True
+        validation_mask[10:] = True
+
+        cumsum = validators.RangeValidator.cumsum_with_reset(ts_diff, validation_mask)
+        self.assertEqual((cumsum > 0.5).sum(), 8)
+
+    def test_cumsum_with_reset_no_timestamps(self) -> None:
+        ts_diff = torch.zeros(20, dtype=torch.float32)
+        validation_mask = torch.zeros(20, dtype=torch.bool)
+        cumsum = validators.RangeValidator.cumsum_with_reset(ts_diff, validation_mask)
+        self.assertEqual(cumsum.sum(), 0.0)
+
+        validation_mask = torch.ones(20, dtype=torch.bool)
+        cumsum = validators.RangeValidator.cumsum_with_reset(ts_diff, validation_mask)
+        self.assertEqual(cumsum.sum(), 0.0)
+
+    def test_cumsum_with_reset_with_timestamps(self) -> None:
+        ts_diff = torch.ones(20, dtype=torch.float32)
+
+        validation_mask = torch.zeros(20, dtype=torch.bool)
+        cumsum = validators.RangeValidator.cumsum_with_reset(ts_diff, validation_mask)
+        self.assertEqual(cumsum.sum(), 0.0)
+
+        # Should match pytorch implementation in this case
+        validation_mask = torch.ones(20, dtype=torch.bool)
+        cumsum = validators.RangeValidator.cumsum_with_reset(ts_diff, validation_mask)
+        self.assertEqual(cumsum.sum(), torch.cumsum(ts_diff, dim=0).sum())


### PR DESCRIPTION
Changes in this PR:

- Adding composite metrics: `PassedDrivenMilesCompositeMetric`, `DrivenMilesCompositeMetric`;
- Adding metrics: `SimulatedDrivenMilesMetric`, `ReplayDrivenMilesMetric`;
- Adding validators: `RangeValidator`
- Unit-testing

The majority of the `RangeValidator` tests depend on the mocked trajectories we have, so I'm porting only a few tests that we have for it now.