### PR TITLE
Adding the closed-loop evaluator (CLE) and validator aggregators

### DIFF
--- a/l5kit/l5kit/cle/validators.py
+++ b/l5kit/l5kit/cle/validators.py
@@ -1,7 +1,6 @@
 from abc import abstractmethod
 from collections import defaultdict
 from enum import IntEnum
-from itertools import chain, cycle
 from typing import Any, DefaultDict, Dict, List, NamedTuple, Optional, Type
 
 import torch

--- a/l5kit/l5kit/tests/cle/test_validators.py
+++ b/l5kit/l5kit/tests/cle/test_validators.py
@@ -96,11 +96,11 @@ class TestValidationFrameAggregator(unittest.TestCase):
         failed_frames.assert_called()
 
         # Size of tensor should be:
-        # 4 failed scene frames * 2 (tuple of scene/frame)
-        # Give that we have only 1 scene
-        self.assertEqual(agg_scenes["mock_validator1"].size(0), 4 * 2)
+        # 4 failed scene frames, given that we have only 1 scene
+        print(agg_scenes)
+        self.assertEqual(agg_scenes["mock_validator1"].size(0), 4)
 
         # Size of tensor should be:
-        # 4 failed scene frames * 2 (tuple of scene/frame) * 2 (scenes)
-        # Give that we have 2 scenes for this validator
-        self.assertEqual(agg_scenes["mock_validator2"].size(0), 4 * 2 * 2)
+        # 4 failed scene frames * 2 (scenes)
+        # Given that we have 2 scenes for this validator
+        self.assertEqual(agg_scenes["mock_validator2"].size(0), 4 * 2)

--- a/l5kit/l5kit/tests/cle/test_validators.py
+++ b/l5kit/l5kit/tests/cle/test_validators.py
@@ -1,5 +1,5 @@
 import unittest
-from typing import Any, Dict
+from typing import Dict
 from unittest import mock
 
 import torch

--- a/l5kit/l5kit/tests/cle/test_validators.py
+++ b/l5kit/l5kit/tests/cle/test_validators.py
@@ -1,6 +1,7 @@
-from typing import Any, Dict
 import unittest
+from typing import Any, Dict
 from unittest import mock
+
 import torch
 
 from l5kit.cle import validators

--- a/l5kit/l5kit/tests/cle/test_validators.py
+++ b/l5kit/l5kit/tests/cle/test_validators.py
@@ -1,5 +1,6 @@
+from typing import Any, Dict
 import unittest
-
+from unittest import mock
 import torch
 
 from l5kit.cle import validators
@@ -36,3 +37,69 @@ class TestRangeValidator(unittest.TestCase):
         validation_mask = torch.ones(20, dtype=torch.bool)
         cumsum = validators.RangeValidator.cumsum_with_reset(ts_diff, validation_mask)
         self.assertEqual(cumsum.sum(), torch.cumsum(ts_diff, dim=0).sum())
+
+
+class TestValidationCountingAggregator(unittest.TestCase):
+    def test_aggregate_scenes(self) -> None:
+        agg = validators.ValidationCountingAggregator()
+        mock_validator_output = mock.Mock()
+        is_valid_scene = mock.PropertyMock(return_value=False)
+        type(mock_validator_output).is_valid_scene = is_valid_scene
+        scene_validation_mock: Dict[int, Dict[str, validators.ValidatorOutput]] = {
+            0: {"mock_validator1": mock_validator_output},
+            1: {"mock_validator2": mock_validator_output},
+            2: {"mock_validator2": mock_validator_output}
+        }
+        agg_scenes = agg.aggregate_scenes(scene_validation_mock)
+        is_valid_scene.assert_called()
+
+        self.assertEqual(len(agg_scenes), 2)
+        self.assertEqual(agg_scenes["mock_validator1"].item(), 1)
+        self.assertEqual(agg_scenes["mock_validator2"].item(), 2)
+
+    def test_aggregate_count_failed_frames(self) -> None:
+        agg = validators.ValidationCountingAggregator(failed_frames=True)
+        mock_validator_output = mock.Mock()
+        is_valid_scene = mock.PropertyMock(return_value=False)
+        failed_frames = mock.PropertyMock(return_value=[1, 2, 3, 4])
+        type(mock_validator_output).is_valid_scene = is_valid_scene
+        type(mock_validator_output).failed_frames = failed_frames
+        scene_validation_mock: Dict[int, Dict[str, validators.ValidatorOutput]] = {
+            0: {"mock_validator1": mock_validator_output},
+            1: {"mock_validator2": mock_validator_output},
+            2: {"mock_validator2": mock_validator_output}
+        }
+        agg_scenes = agg.aggregate_scenes(scene_validation_mock)
+        failed_frames.assert_called()
+
+        self.assertEqual(len(agg_scenes), 2)
+        self.assertEqual(agg_scenes["mock_validator1"].item(), 4)
+        self.assertEqual(agg_scenes["mock_validator2"].item(), 8)
+
+
+class TestValidationFrameAggregator(unittest.TestCase):
+    def test_aggregate_scenes(self) -> None:
+        agg = validators.ValidationFailedFramesAggregator()
+
+        mock_validator_output = mock.Mock()
+        failed_frames = mock.PropertyMock(return_value=[1, 2, 3, 4])
+        type(mock_validator_output).failed_frames = failed_frames
+
+        # 3 scenes
+        scene_validation_mock: Dict[int, Dict[str, validators.ValidatorOutput]] = {
+            0: {"mock_validator1": mock_validator_output},
+            1: {"mock_validator2": mock_validator_output},
+            2: {"mock_validator2": mock_validator_output}
+        }
+        agg_scenes = agg.aggregate_scenes(scene_validation_mock)
+        failed_frames.assert_called()
+
+        # Size of tensor should be:
+        # 4 failed scene frames * 2 (tuple of scene/frame)
+        # Give that we have only 1 scene
+        self.assertEqual(agg_scenes["mock_validator1"].size(0), 4 * 2)
+
+        # Size of tensor should be:
+        # 4 failed scene frames * 2 (tuple of scene/frame) * 2 (scenes)
+        # Give that we have 2 scenes for this validator
+        self.assertEqual(agg_scenes["mock_validator2"].size(0), 4 * 2 * 2)


### PR DESCRIPTION
Adding the closed-loop evaluator (`ClosedLoopEvaluator`) and some aggregators for the validators (`SupportsValidationAggregation`, `ValidationCountingAggregator`) as well as testing for the aggregators. Tests for the `ClosedLoopEvaluator` depend on the mocked trajectories that we don't have yet.

Next PR will be aggregators of metrics and composite metrics.