### PR TITLE
[AVR-976] Fix simulation source scenes

### DIFF
--- a/l5kit/l5kit/simulation/dataset.py
+++ b/l5kit/l5kit/simulation/dataset.py
@@ -19,7 +19,7 @@ class SimulationConfig(NamedTuple):
     :param distance_th_close: if a new agent is closer than this value to ego, it will be controlled
     :param start_frame_index: the start index of the simulation
     :param num_simulation_steps: the number of step to simulate
-    :param disable_tqdm: whether to disable tqdm during unroll
+    :param show_info: whether to show info logging during unroll
     """
     use_ego_gt: bool
     use_agents_gt: bool
@@ -28,7 +28,7 @@ class SimulationConfig(NamedTuple):
     distance_th_close: float
     start_frame_index: int = 0
     num_simulation_steps: Optional[int] = None
-    disable_tqdm: bool = True
+    show_info: bool = False
 
 
 class SimulationDataset:

--- a/l5kit/l5kit/simulation/dataset.py
+++ b/l5kit/l5kit/simulation/dataset.py
@@ -6,7 +6,7 @@ import numpy as np
 from l5kit.data import filter_agents_by_frames, PERCEPTION_LABEL_TO_INDEX
 from l5kit.dataset import EgoDataset
 from l5kit.geometry.transform import yaw_as_rotation33
-from l5kit.simulation.utils import disable_agents, insert_agent
+from l5kit.simulation.utils import disable_agents, get_frames_subset, insert_agent
 
 
 class SimulationConfig(NamedTuple):
@@ -46,19 +46,30 @@ class SimulationDataset:
         if not len(scene_dataset_batch):
             raise ValueError("can't build a simulation dataset with an empty batch")
         self.scene_dataset_batch: Dict[int, EgoDataset] = scene_dataset_batch
+        self.sim_cfg = sim_cfg
+
+        # we must limit the scenes to the part which will be simulated
+        # we cut each scene so that it starts from there and ends after `num_simulation_steps`
+        start_frame_idx = self.sim_cfg.start_frame_index
+        if self.sim_cfg.num_simulation_steps is None:
+            end_frame_idx = min([len(scene_dt.dataset.frames) for scene_dt in self.scene_dataset_batch.values()])
+        else:
+            end_frame_idx = start_frame_idx + self.sim_cfg.num_simulation_steps
+
+        for scene_idx in scene_dataset_batch:
+            zarr_dt = self.scene_dataset_batch[scene_idx].dataset
+            self.scene_dataset_batch[scene_idx].dataset = get_frames_subset(zarr_dt, start_frame_idx, end_frame_idx)
 
         self._len = min([len(scene_dt.dataset.frames) for scene_dt in self.scene_dataset_batch.values()])
-
-        self.sim_cfg = sim_cfg
 
         # buffer used to keep track of tracked agents during unroll as tuples of scene_idx, agent_idx
         self._agents_tracked: Set[Tuple[int, int]] = set()
 
         if self.sim_cfg.disable_new_agents:
-            # we disable all agents that wouldn't be picked at start_frame
+            # we disable all agents that wouldn't be picked at frame 0
             for scene_idx, dt_ego in self.scene_dataset_batch.items():
                 dataset_zarr = dt_ego.dataset
-                frame = dataset_zarr.frames[self.sim_cfg.start_frame_index]
+                frame = dataset_zarr.frames[0]
                 ego_pos = frame["ego_translation"][:2]
                 agents = dataset_zarr.agents
                 frame_agents = filter_agents_by_frames(frame, agents)[0]

--- a/l5kit/l5kit/simulation/dataset.py
+++ b/l5kit/l5kit/simulation/dataset.py
@@ -60,6 +60,10 @@ class SimulationDataset:
             zarr_dt = self.scene_dataset_batch[scene_idx].dataset
             self.scene_dataset_batch[scene_idx].dataset = get_frames_subset(zarr_dt, start_frame_idx, end_frame_idx)
 
+            # this is the only stateful field we need to change for EgoDataset, it's used in bisect
+            frame_index_ends = self.scene_dataset_batch[scene_idx].dataset.scenes["frame_index_interval"][:, 1]
+            self.scene_dataset_batch[scene_idx].cumulative_sizes = frame_index_ends
+
         self._len = min([len(scene_dt.dataset.frames) for scene_dt in self.scene_dataset_batch.values()])
 
         # buffer used to keep track of tracked agents during unroll as tuples of scene_idx, agent_idx

--- a/l5kit/l5kit/simulation/unroll.py
+++ b/l5kit/l5kit/simulation/unroll.py
@@ -117,7 +117,7 @@ class ClosedLoopSimulator:
         """
         sim_dataset = SimulationDataset.from_dataset_indices(self.dataset, scene_indices, self.sim_cfg)
 
-        for frame_index in tqdm(range(len(sim_dataset))):
+        for frame_index in tqdm(range(len(sim_dataset)), disable=self.sim_cfg.disable_tqdm):
             next_frame_index = frame_index + 1
             should_update = next_frame_index != len(sim_dataset)
 

--- a/l5kit/l5kit/simulation/unroll.py
+++ b/l5kit/l5kit/simulation/unroll.py
@@ -117,7 +117,7 @@ class ClosedLoopSimulator:
         """
         sim_dataset = SimulationDataset.from_dataset_indices(self.dataset, scene_indices, self.sim_cfg)
 
-        for frame_index in tqdm(range(len(sim_dataset)), disable=self.sim_cfg.disable_tqdm):
+        for frame_index in tqdm(range(len(sim_dataset)), disable=not self.sim_cfg.show_info):
             next_frame_index = frame_index + 1
             should_update = next_frame_index != len(sim_dataset)
 

--- a/l5kit/l5kit/simulation/unroll.py
+++ b/l5kit/l5kit/simulation/unroll.py
@@ -117,15 +117,9 @@ class ClosedLoopSimulator:
         """
         sim_dataset = SimulationDataset.from_dataset_indices(self.dataset, scene_indices, self.sim_cfg)
 
-        if self.sim_cfg.num_simulation_steps is None:
-            range_unroll = range(self.sim_cfg.start_frame_index, len(sim_dataset))
-        else:
-            end_frame_index = min(len(sim_dataset), self.sim_cfg.num_simulation_steps + self.sim_cfg.start_frame_index)
-            range_unroll = range(self.sim_cfg.start_frame_index, end_frame_index)
-
-        for frame_index in tqdm(range_unroll):
+        for frame_index in tqdm(range(len(sim_dataset))):
             next_frame_index = frame_index + 1
-            should_update = next_frame_index != range_unroll.stop
+            should_update = next_frame_index != len(sim_dataset)
 
             # AGENTS
             if not self.sim_cfg.use_agents_gt:

--- a/l5kit/l5kit/simulation/utils.py
+++ b/l5kit/l5kit/simulation/utils.py
@@ -6,8 +6,8 @@ from l5kit.data import ChunkedDataset, get_agents_slice_from_frames, get_tl_face
 def insert_agent(agent: np.ndarray, frame_idx: int, dataset: ChunkedDataset) -> None:
     """Insert an agent in one frame.
     Assumptions:
-        the dataset has only 1 scene
-        the dataset is in numpy format and not zarr anymore
+        - the dataset has only 1 scene
+        - the dataset is in numpy format and not zarr anymore
 
     :param agent: the agent info to be inserted
     :param frame_idx: the frame where we want to insert the agent
@@ -50,8 +50,8 @@ def insert_agent(agent: np.ndarray, frame_idx: int, dataset: ChunkedDataset) -> 
 def disable_agents(dataset: ChunkedDataset, allowlist: np.ndarray) -> None:
     """Disable all agents in dataset except for the ones in allowlist
     Assumptions:
-        the dataset has only 1 scene
-        the dataset is in numpy format and not zarr anymore
+        - the dataset has only 1 scene
+        - the dataset is in numpy format and not zarr anymore
 
     :param dataset: the single-scene dataset
     :param allowlist: 1D np array of track_ids to keep
@@ -79,8 +79,8 @@ def disable_agents(dataset: ChunkedDataset, allowlist: np.ndarray) -> None:
 def get_frames_subset(dataset: ChunkedDataset, frame_start_idx: int, frame_end_idx: int) -> ChunkedDataset:
     """Get a new dataset with frames between start (included) and end (excluded).
     Assumptions:
-        the dataset has only 1 scene
-        the dataset is in numpy format and not zarr anymore
+        - the dataset has only 1 scene
+        - the dataset is in numpy format and not zarr anymore
 
     :param dataset: the single-scene dataset.
     :param frame_start_idx: first frame to keep.

--- a/l5kit/l5kit/simulation/utils.py
+++ b/l5kit/l5kit/simulation/utils.py
@@ -106,11 +106,12 @@ def get_frames_subset(dataset: ChunkedDataset, frame_start_idx: int, frame_end_i
 
     new_dataset = ChunkedDataset("")
     new_dataset.scenes = dataset.scenes.copy()
-    new_dataset.scenes[0]["frame_index_interval"] = (frame_start_idx, frame_end_idx)
     new_dataset.scenes[0]["start_time"] = dataset.frames[frame_start_idx]["timestamp"]
     new_dataset.scenes[0]["end_time"] = dataset.frames[frame_end_idx - 1]["timestamp"]
 
     new_dataset.frames = dataset.frames[frame_start_idx:frame_end_idx].copy()
+    new_dataset.scenes[0]["frame_index_interval"] = (0, len(new_dataset.frames))
+
     agent_slice = get_agents_slice_from_frames(*dataset.frames[[frame_start_idx, frame_end_idx - 1]])
     tls_slice = get_tl_faces_slice_from_frames(*dataset.frames[[frame_start_idx, frame_end_idx - 1]])
     new_dataset.frames["agent_index_interval"] -= new_dataset.frames["agent_index_interval"][0, 0]

--- a/l5kit/l5kit/simulation/utils.py
+++ b/l5kit/l5kit/simulation/utils.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from l5kit.data import ChunkedDataset, get_agents_slice_from_frames
+from l5kit.data import ChunkedDataset, get_agents_slice_from_frames, get_tl_faces_slice_from_frames
 
 
 def insert_agent(agent: np.ndarray, frame_idx: int, dataset: ChunkedDataset) -> None:
@@ -74,3 +74,49 @@ def disable_agents(dataset: ChunkedDataset, allowlist: np.ndarray) -> None:
     dataset.agents["yaw"][mask_disable] *= 0
     dataset.agents["extent"][mask_disable] *= 0
     dataset.agents["label_probabilities"][mask_disable] = -1
+
+
+def get_frames_subset(dataset: ChunkedDataset, frame_start_idx: int, frame_end_idx: int) -> ChunkedDataset:
+    """Get a new dataset with frames between start (included) and end (excluded).
+    Assumptions:
+        the dataset has only 1 scene
+        the dataset is in numpy format and not zarr anymore
+
+    :param dataset: the single-scene dataset.
+    :param frame_start_idx: first frame to keep.
+    :param frame_end_idx: where to stop taking frames (excluded).
+
+    """
+    if not len(dataset.scenes) == 1:
+        raise ValueError(f"dataset should have a single scene, got {len(dataset.scenes)}")
+    if not isinstance(dataset.agents, np.ndarray):
+        raise ValueError("dataset agents should be an editable np array")
+    if not isinstance(dataset.tl_faces, np.ndarray):
+        raise ValueError("dataset tls should be an editable np array")
+    if not isinstance(dataset.frames, np.ndarray):
+        raise ValueError("dataset frames should be an editable np array")
+    if frame_start_idx >= len(dataset.frames):
+        raise ValueError(f"frame start {frame_start_idx} is over the length of the dataset")
+    if frame_end_idx > len(dataset.frames):
+        raise ValueError(f"frame end {frame_end_idx} is over the length of the dataset")
+    if frame_start_idx >= frame_end_idx:
+        raise ValueError(f"end frame {frame_end_idx} should be higher than start {frame_start_idx}")
+    if frame_start_idx < 0:
+        raise ValueError(f"start frame {frame_start_idx} should be positive")
+
+    new_dataset = ChunkedDataset("")
+    new_dataset.scenes = dataset.scenes.copy()
+    new_dataset.scenes[0]["frame_index_interval"] = (frame_start_idx, frame_end_idx)
+    new_dataset.scenes[0]["start_time"] = dataset.frames[frame_start_idx]["timestamp"]
+    new_dataset.scenes[0]["end_time"] = dataset.frames[frame_end_idx - 1]["timestamp"]
+
+    new_dataset.frames = dataset.frames[frame_start_idx:frame_end_idx].copy()
+    agent_slice = get_agents_slice_from_frames(*dataset.frames[[frame_start_idx, frame_end_idx - 1]])
+    tls_slice = get_tl_faces_slice_from_frames(*dataset.frames[[frame_start_idx, frame_end_idx - 1]])
+    new_dataset.frames["agent_index_interval"] -= new_dataset.frames["agent_index_interval"][0, 0]
+    new_dataset.frames["traffic_light_faces_index_interval"] -= new_dataset.frames[
+        "traffic_light_faces_index_interval"
+    ][0, 0]
+    new_dataset.agents = dataset.agents[agent_slice].copy()
+    new_dataset.tl_faces = dataset.tl_faces[tls_slice].copy()
+    return new_dataset

--- a/l5kit/l5kit/tests/simulation/utils_test.py
+++ b/l5kit/l5kit/tests/simulation/utils_test.py
@@ -291,6 +291,7 @@ def test_dataset_frames_subset(zarr_dataset: ChunkedDataset) -> None:
 
     assert np.all(zarr_cut.agents == zarr_dataset.agents[agents_slice])
     assert np.all(zarr_cut.tl_faces == zarr_dataset.tl_faces[tls_slice])
+    assert np.all(zarr_cut.scenes["frame_index_interval"] == (0, len(zarr_cut.frames)))
 
 
 def test_mock_dataset_frames_subset() -> None:


### PR DESCRIPTION
Right now we're not cutting the datasets to the range which will be simulated. This may introduce issues (e.g. in visualisation and metrics). This PR address this

- [x] add util
- [x] test util
- [x] use util in simulation
- [x] add specific test for unroll loop