### PR TITLE
Adding collision metrics for the closed-loop evaluator

### DIFF
--- a/l5kit/l5kit/cle/metrics.py
+++ b/l5kit/l5kit/cle/metrics.py
@@ -1,11 +1,13 @@
-from abc import abstractmethod
+from abc import ABC, abstractmethod
 
+import numpy as np
 import torch
 from typing_extensions import Protocol
 
 from l5kit.evaluation import error_functions
 from l5kit.evaluation import metrics as l5metrics
-from l5kit.simulation.unroll import SimulationOutput
+from l5kit.rasterization import EGO_EXTENT_LENGTH, EGO_EXTENT_WIDTH
+from l5kit.simulation.unroll import SimulationOutput, TrajectoryStateIndices
 
 
 class SupportsMetricCompute(Protocol):
@@ -21,6 +23,84 @@ class SupportsMetricCompute(Protocol):
         :returns: a tensor with the result of the metric per frame
         """
         raise NotImplementedError
+
+
+class CollisionMetricBase(ABC):
+    """This is the abstract base class for the collision metric.
+
+    :param collision_type: the type of collision to compute
+    """
+    @abstractmethod
+    def __init__(self, collision_type: l5metrics.CollisionType) -> None:
+        self.collision_type = collision_type
+
+    def _compute_frame(self, recorded_agents: np.ndarray,
+                       simulated_frame_ego_state: torch.Tensor) -> float:
+        """Detects collision per frame of the scene.
+
+        :param observed_frame: the ground-truth frame
+        :param simulated_frame_ego_state: ego state from the simulated frame,
+                                          this is a 1D array with the frame
+                                          ego state
+        :returns: metric result for the frame, where 1 means a collision,
+                  and 0 otherwise.
+        """
+        simulated_centroid = simulated_frame_ego_state[:TrajectoryStateIndices.Y + 1].cpu().numpy()
+        simulated_angle = simulated_frame_ego_state[TrajectoryStateIndices.THETA].cpu().numpy()
+        simulated_extent = np.r_[EGO_EXTENT_LENGTH, EGO_EXTENT_WIDTH]
+        collision_ret = l5metrics.detect_collision(simulated_centroid, simulated_angle,
+                                                   simulated_extent, recorded_agents)
+        if collision_ret is not None:
+            if collision_ret[0] == self.collision_type:
+                return 1.0
+
+        return 0.0
+
+    def compute(self, simulation_output: SimulationOutput) -> torch.Tensor:
+        """Compute the metric on all frames of the scene.
+
+        :param simulation_output: the output from the closed-loop simulation
+        :returns: collision per frame (a 1D array with the same size of the
+                  number of frames, where 1 means a colision, 0 otherwise)
+        """
+        simulated_scene_ego_state = simulation_output.simulated_ego_states
+        recorded_agents = simulation_output.recorded_agents
+
+        if len(recorded_agents) < len(simulated_scene_ego_state):
+            raise ValueError("More simulated timesteps than observed.")
+
+        num_frames = simulated_scene_ego_state.size(0)
+        metric_results = torch.zeros(num_frames, device=simulated_scene_ego_state.device)
+        for frame_idx in range(num_frames):
+            recorded_agent_frame = recorded_agents[frame_idx]
+            simulated_frame_ego_frame = simulated_scene_ego_state[frame_idx]
+            result = self._compute_frame(recorded_agent_frame, simulated_frame_ego_frame)
+            metric_results[frame_idx] = result
+        return metric_results
+
+
+class CollisionFrontMetric(CollisionMetricBase):
+    """Computes the front collision metric."""
+    metric_name = "collision_front"
+
+    def __init__(self) -> None:
+        super().__init__(l5metrics.CollisionType.FRONT)
+
+
+class CollisionRearMetric(CollisionMetricBase):
+    """Computes the rear collision metric."""
+    metric_name = "collision_rear"
+
+    def __init__(self) -> None:
+        super().__init__(l5metrics.CollisionType.REAR)
+
+
+class CollisionSideMetric(CollisionMetricBase):
+    """Computes the side collision metric."""
+    metric_name = "collision_side"
+
+    def __init__(self) -> None:
+        super().__init__(l5metrics.CollisionType.SIDE)
 
 
 class DisplacementErrorMetric(SupportsMetricCompute):

--- a/l5kit/l5kit/cle/metrics.py
+++ b/l5kit/l5kit/cle/metrics.py
@@ -34,7 +34,7 @@ class CollisionMetricBase(ABC):
     def __init__(self, collision_type: l5metrics.CollisionType) -> None:
         self.collision_type = collision_type
 
-    def _compute_frame(self, recorded_agents: np.ndarray,
+    def _compute_frame(self, simulated_agent_frame: np.ndarray,
                        simulated_frame_ego_state: torch.Tensor) -> float:
         """Detects collision per frame of the scene.
 
@@ -49,7 +49,7 @@ class CollisionMetricBase(ABC):
         simulated_angle = simulated_frame_ego_state[TrajectoryStateIndices.THETA].cpu().numpy()
         simulated_extent = np.r_[EGO_EXTENT_LENGTH, EGO_EXTENT_WIDTH]
         collision_ret = l5metrics.detect_collision(simulated_centroid, simulated_angle,
-                                                   simulated_extent, recorded_agents)
+                                                   simulated_extent, simulated_agent_frame)
         if collision_ret is not None:
             if collision_ret[0] == self.collision_type:
                 return 1.0
@@ -72,9 +72,9 @@ class CollisionMetricBase(ABC):
         num_frames = simulated_scene_ego_state.size(0)
         metric_results = torch.zeros(num_frames, device=simulated_scene_ego_state.device)
         for frame_idx in range(num_frames):
-            recorded_agent_frame = simulated_agents[frame_idx]
+            simulated_agent_frame = simulated_agents[frame_idx]
             simulated_frame_ego_frame = simulated_scene_ego_state[frame_idx]
-            result = self._compute_frame(recorded_agent_frame, simulated_frame_ego_frame)
+            result = self._compute_frame(simulated_agent_frame, simulated_frame_ego_frame)
             metric_results[frame_idx] = result
         return metric_results
 

--- a/l5kit/l5kit/cle/metrics.py
+++ b/l5kit/l5kit/cle/metrics.py
@@ -64,15 +64,15 @@ class CollisionMetricBase(ABC):
                   number of frames, where 1 means a colision, 0 otherwise)
         """
         simulated_scene_ego_state = simulation_output.simulated_ego_states
-        recorded_agents = simulation_output.recorded_agents
+        simulated_agents = simulation_output.simulated_agents
 
-        if len(recorded_agents) < len(simulated_scene_ego_state):
+        if len(simulated_agents) < len(simulated_scene_ego_state):
             raise ValueError("More simulated timesteps than observed.")
 
         num_frames = simulated_scene_ego_state.size(0)
         metric_results = torch.zeros(num_frames, device=simulated_scene_ego_state.device)
         for frame_idx in range(num_frames):
-            recorded_agent_frame = recorded_agents[frame_idx]
+            recorded_agent_frame = simulated_agents[frame_idx]
             simulated_frame_ego_frame = simulated_scene_ego_state[frame_idx]
             result = self._compute_frame(recorded_agent_frame, simulated_frame_ego_frame)
             metric_results[frame_idx] = result

--- a/l5kit/l5kit/tests/cle/test_metrics.py
+++ b/l5kit/l5kit/tests/cle/test_metrics.py
@@ -1,10 +1,41 @@
 import unittest
+from typing import Any
 from unittest import mock
 
 import torch
 
 from l5kit.cle import metrics
 from l5kit.evaluation import error_functions
+from l5kit.evaluation import metrics as l5metrics
+
+
+class TestCollisionMetric(unittest.TestCase):
+    @staticmethod
+    def create_dummy_metric(dummy_metric_name: str = "dummy_metric") -> Any:
+        class DummyMetric(metrics.CollisionMetricBase):
+            metric_name = dummy_metric_name
+
+            def __init__(self) -> None:
+                super().__init__(l5metrics.CollisionType.FRONT)
+
+        return DummyMetric()
+
+    def test_attributes(self) -> None:
+        dummy_metric_name = "dummy_metric"
+        dummy_metric = TestCollisionMetric.create_dummy_metric(dummy_metric_name)
+        self.assertEqual(dummy_metric.collision_type,
+                         l5metrics.CollisionType.FRONT)
+        self.assertEqual(dummy_metric.metric_name,
+                         dummy_metric_name)
+
+    def test_collision_types(self) -> None:
+        collision_metric_match = {
+            l5metrics.CollisionType.FRONT: metrics.CollisionFrontMetric(),
+            l5metrics.CollisionType.SIDE: metrics.CollisionSideMetric(),
+            l5metrics.CollisionType.REAR: metrics.CollisionRearMetric(),
+        }
+        for collision_type, metric in collision_metric_match.items():
+            self.assertEqual(metric.collision_type, collision_type)
 
 
 class TestDisplacementErrorMetric(unittest.TestCase):


### PR DESCRIPTION
This PR will add the collision metrics, the tests also depend on the custom mocked data.
I'm using here the `simulation_output.recorded_agents` but I'm not sure about what should come in this array, so I'll submit this PR and then when we have data coming in I can change and fix it.