### PR TITLE
[WIP] Dataset Refactor

### DIFF
--- a/l5kit/l5kit/dataset/__init__.py
+++ b/l5kit/l5kit/dataset/__init__.py
@@ -1,6 +1,6 @@
 from .agent import AgentDataset
-from .ego import EgoDataset
+from .ego import BaseEgoDataset, EgoDataset
 from .select_agents import select_agents
 from .ego_vectorized import EgoDatasetVectorized
 
-__all__ = ["EgoDataset", "EgoDatasetVectorized", "AgentDataset", "select_agents"]
+__all__ = ["BaseEgoDataset", "EgoDataset", "EgoDatasetVectorized", "AgentDataset", "select_agents"]

--- a/l5kit/l5kit/dataset/ego.py
+++ b/l5kit/l5kit/dataset/ego.py
@@ -1,7 +1,7 @@
 import bisect
 import warnings
 from functools import partial
-from typing import Optional
+from typing import Callable, Optional
 
 import numpy as np
 from torch.utils.data import Dataset
@@ -13,13 +13,11 @@ from ..sampling import generate_agent_sample
 from .utils import convert_str_to_fixed_length_tensor
 
 
-class EgoDataset(Dataset):
+class BaseEgoDataset(Dataset):
     def __init__(
             self,
             cfg: dict,
             zarr_dataset: ChunkedDataset,
-            rasterizer: Rasterizer,
-            perturbation: Optional[Perturbation] = None,
     ):
         """
         Get a PyTorch dataset object that can be used to train DNN
@@ -27,35 +25,16 @@ class EgoDataset(Dataset):
         Args:
             cfg (dict): configuration file
             zarr_dataset (ChunkedDataset): the raw zarr dataset
-            rasterizer (Rasterizer): an object that support rasterisation around an agent (AV or not)
-            perturbation (Optional[Perturbation]): an object that takes care of applying trajectory perturbations.
-None if not desired
         """
-        self.perturbation = perturbation
         self.cfg = cfg
         self.dataset = zarr_dataset
-        self.rasterizer = rasterizer
-
         self.cumulative_sizes = self.dataset.scenes["frame_index_interval"][:, 1]
 
-        render_context = RenderContext(
-            raster_size_px=np.array(cfg["raster_params"]["raster_size"]),
-            pixel_size_m=np.array(cfg["raster_params"]["pixel_size"]),
-            center_in_raster_ratio=np.array(cfg["raster_params"]["ego_center"]),
-            set_origin_to_bottom=cfg["raster_params"]["set_origin_to_bottom"],
-        )
-
         # build a partial so we don't have to access cfg each time
-        self.sample_function = partial(
-            generate_agent_sample,
-            render_context=render_context,
-            history_num_frames=cfg["model_params"]["history_num_frames"],
-            future_num_frames=cfg["model_params"]["future_num_frames"],
-            step_time=cfg["model_params"]["step_time"],
-            filter_agents_threshold=cfg["raster_params"]["filter_agents_threshold"],
-            rasterizer=rasterizer,
-            perturbation=perturbation,
-        )
+        self.sample_function = self._get_sample_function()
+
+    def _get_sample_function(self) -> Callable:
+        raise NotImplementedError()
 
     def __len__(self) -> int:
         """
@@ -132,7 +111,7 @@ None if not desired
             state_index = index - self.cumulative_sizes[scene_index - 1]
         return self.get_frame(scene_index, state_index)
 
-    def get_scene_dataset(self, scene_index: int) -> "EgoDataset":
+    def get_scene_dataset(self, scene_index: int) -> "BaseEgoDataset":
         """
         Returns another EgoDataset dataset where the underlying data can be modified.
         This is possible because, even if it supports the same interface, this dataset is np.ndarray based.
@@ -145,7 +124,7 @@ None if not desired
 
         """
         dataset = self.dataset.get_scene_dataset(scene_index)
-        return EgoDataset(self.cfg, dataset, self.rasterizer, self.perturbation)
+        return BaseEgoDataset(self.cfg, dataset)
 
     def get_scene_indices(self, scene_idx: int) -> np.ndarray:
         """
@@ -176,3 +155,60 @@ None if not desired
 
     def __str__(self) -> str:
         return self.dataset.__str__()
+
+
+class EgoDataset(BaseEgoDataset):
+    def __init__(
+            self,
+            cfg: dict,
+            zarr_dataset: ChunkedDataset,
+            rasterizer: Rasterizer,
+            perturbation: Optional[Perturbation] = None,
+    ):
+        """
+        Get a PyTorch dataset object that can be used to train DNN
+
+        Args:
+            cfg (dict): configuration file
+            zarr_dataset (ChunkedDataset): the raw zarr dataset
+            rasterizer (Rasterizer): an object that support rasterisation around an agent (AV or not)
+            perturbation (Optional[Perturbation]): an object that takes care of applying trajectory perturbations.
+            None if not desired
+        """
+        self.perturbation = perturbation
+        self.rasterizer = rasterizer
+        super().__init__(cfg, zarr_dataset)
+
+    def _get_sample_function(self) -> Callable:
+        render_context = RenderContext(
+            raster_size_px=np.array(self.cfg["raster_params"]["raster_size"]),
+            pixel_size_m=np.array(self.cfg["raster_params"]["pixel_size"]),
+            center_in_raster_ratio=np.array(self.cfg["raster_params"]["ego_center"]),
+            set_origin_to_bottom=self.cfg["raster_params"]["set_origin_to_bottom"],
+        )
+
+        return partial(
+            generate_agent_sample,
+            render_context=render_context,
+            history_num_frames=self.cfg["model_params"]["history_num_frames"],
+            future_num_frames=self.cfg["model_params"]["future_num_frames"],
+            step_time=self.cfg["model_params"]["step_time"],
+            filter_agents_threshold=self.cfg["raster_params"]["filter_agents_threshold"],
+            rasterizer=self.rasterizer,
+            perturbation=self.perturbation,
+        )
+
+    def get_scene_dataset(self, scene_index: int) -> "EgoDataset":
+        """
+        Returns another EgoDataset dataset where the underlying data can be modified.
+        This is possible because, even if it supports the same interface, this dataset is np.ndarray based.
+
+        Args:
+            scene_index (int): the scene index of the new dataset
+
+        Returns:
+            EgoDataset: A valid EgoDataset dataset with a copy of the data
+
+        """
+        dataset = self.dataset.get_scene_dataset(scene_index)
+        return EgoDataset(self.cfg, dataset, self.rasterizer, self.perturbation)

--- a/l5kit/l5kit/dataset/ego_vectorized.py
+++ b/l5kit/l5kit/dataset/ego_vectorized.py
@@ -1,23 +1,19 @@
 
-from typing import Optional
+from typing import Optional, Callable
 from functools import partial
 
-import numpy as np
-
 from l5kit.kinematic import Perturbation
-from l5kit.rasterization import Rasterizer
-from l5kit.dataset import EgoDataset
+from l5kit.dataset import BaseEgoDataset
 from l5kit.data import ChunkedDataset
-from l5kit.rasterization import RenderContext
 from l5kit.vectorization.vectorizer import Vectorizer
 from ..sampling import generate_agent_sample_vectorized
 
-class EgoDatasetVectorized(EgoDataset):
+
+class EgoDatasetVectorized(BaseEgoDataset):
     def __init__(
         self,
         cfg: dict,
         zarr_dataset: ChunkedDataset,
-        rasterizer: Rasterizer,
         vectorizer: Vectorizer,
         perturbation: Optional[Perturbation] = None,
     ):
@@ -27,34 +23,26 @@ class EgoDatasetVectorized(EgoDataset):
         Args:
             cfg (dict): configuration file
             zarr_dataset (ChunkedDataset): the raw zarr dataset
-            rasterizer (Rasterizer): an object that support rasterisation around an agent (AV or not) - optional for viz [TODO]
             vectorizer (Vectorizer): a object that supports vectorization around an AV
             perturbation (Optional[Perturbation]): an object that takes care of applying trajectory perturbations.
-        None if not desired 
+        None if not desired
         """
-        super().__init__(cfg, zarr_dataset, rasterizer, perturbation)
+        self.perturbation = perturbation
+        self.vectorizer = vectorizer
+        super().__init__(cfg, zarr_dataset)
 
-        # replace the sample function to access other agents
-        # TODO: lberg to check - comment not understandable
-        render_context = RenderContext(
-            raster_size_px=np.array(cfg["raster_params"]["raster_size"]),
-            pixel_size_m=np.array(cfg["raster_params"]["pixel_size"]),
-            center_in_raster_ratio=np.array(cfg["raster_params"]["ego_center"]),
-            set_origin_to_bottom=cfg["raster_params"]["set_origin_to_bottom"],
-        )
-        self.sample_function = partial(
+    def _get_sample_function(self) -> Callable:
+        return partial(
             generate_agent_sample_vectorized,
-            render_context=render_context,
-            history_num_frames_ego=cfg["model_params"]["history_num_frames_ego"],
-            history_num_frames_agents=cfg["model_params"]["history_num_frames_agents"],
-            future_num_frames=cfg["model_params"]["future_num_frames"],
-            step_time=cfg["model_params"]["step_time"],
-            filter_agents_threshold=cfg["raster_params"]["filter_agents_threshold"],
-            rasterizer=rasterizer,
-            perturbation=perturbation,
-            vectorizer=vectorizer
+            history_num_frames_ego=self.cfg["model_params"]["history_num_frames_ego"],
+            history_num_frames_agents=self.cfg["model_params"]["history_num_frames_agents"],
+            future_num_frames=self.cfg["model_params"]["future_num_frames"],
+            step_time=self.cfg["model_params"]["step_time"],
+            filter_agents_threshold=self.cfg["raster_params"]["filter_agents_threshold"],
+            perturbation=self.perturbation,
+            vectorizer=self.vectorizer
         )
 
     def get_scene_dataset(self, scene_index: int) -> "EgoDatasetVectorized":
         dataset = super().get_scene_dataset(scene_index).dataset
-        return EgoDatasetVectorized(self.cfg, dataset, self.rasterizer, self.perturbation)
+        return EgoDatasetVectorized(self.cfg, dataset, self.vectorizer, self.perturbation)

--- a/l5kit/l5kit/sampling/agent_sampling.py
+++ b/l5kit/l5kit/sampling/agent_sampling.py
@@ -10,6 +10,7 @@ from ..kinematic import Perturbation
 from ..rasterization import EGO_EXTENT_HEIGHT, EGO_EXTENT_LENGTH, EGO_EXTENT_WIDTH, Rasterizer, RenderContext
 from .slicing import get_future_slice, get_history_slice
 
+
 def get_agent_context(
         state_index: int,
         frames: np.ndarray,

--- a/l5kit/l5kit/sampling/agent_sampling_vectorized.py
+++ b/l5kit/l5kit/sampling/agent_sampling_vectorized.py
@@ -6,7 +6,7 @@ from ..data import filter_agents_by_labels, PERCEPTION_LABEL_TO_INDEX
 from ..data.filter import filter_agents_by_track_id
 from ..geometry import compute_agent_pose, rotation33_as_yaw
 from ..kinematic import Perturbation
-from ..rasterization import EGO_EXTENT_HEIGHT, EGO_EXTENT_LENGTH, EGO_EXTENT_WIDTH, RenderContext
+from ..rasterization import EGO_EXTENT_HEIGHT, EGO_EXTENT_LENGTH, EGO_EXTENT_WIDTH
 from l5kit.vectorization.vectorizer import Vectorizer
 
 from ..sampling import get_agent_context, get_relative_poses, compute_agent_velocity
@@ -26,9 +26,9 @@ def generate_agent_sample_vectorized(
     vectorizer: Vectorizer,
     perturbation: Optional[Perturbation] = None,
 ) -> dict:
-    """Generates the inputs and targets to train a deep prediction model with vectorized inputs. A deep prediction model takes as input
-    the state of the world in vectorized form, and outputs where that agent will be some
-    seconds into the future.
+    """Generates the inputs and targets to train a deep prediction model with vectorized inputs.
+    A deep prediction model takes as input the state of the world in vectorized form,
+    and outputs where that agent will be some seconds into the future.
 
     This function has a lot of arguments and is intended for internal use, you should try to use higher level classes
     and partials that use this function.
@@ -41,14 +41,12 @@ def generate_agent_sample_vectorized(
         selected_track_id (Optional[int]): Either None for AV, or the ID of an agent that you want to
         predict the future of. This agent is centered in the representation and the returned targets are derived from
         their future states.
-        render_context (RenderContext): The context for rasterisation & vectorization
         history_num_frames_ego (int): Amount of ego history frames to include
         history_num_frames_agents (int): Amount of agent history frames to include
         future_num_frames (int): Amount of future frames to include
         step_time (float): seconds between consecutive steps
         filter_agents_threshold (float): Value between 0 and 1 to use as cutoff value for agent filtering
         based on their probability of being a relevant agent
-        rasterizer (Optional[Rasterizer]): Rasterizer of some sort that draws a map image - is here used for visualization only [TODO]
         perturbation (Optional[Perturbation]): Object that perturbs the input and targets, used
         to train models that can recover from slight divergence from training set data
 
@@ -113,10 +111,10 @@ def generate_agent_sample_vectorized(
         history_num_frames_max + 1, history_frames, selected_track_id, history_agents, agent_from_world, agent_yaw_rad
     )
 
-    history_coords_offset[history_num_frames_ego + 1 :] *= 0
-    history_yaws_offset[history_num_frames_ego + 1 :] *= 0
-    history_extents[history_num_frames_ego + 1 :] *= 0
-    history_availability[history_num_frames_ego + 1 :] *= 0
+    history_coords_offset[history_num_frames_ego + 1:] *= 0
+    history_yaws_offset[history_num_frames_ego + 1:] *= 0
+    history_extents[history_num_frames_ego + 1:] *= 0
+    history_availability[history_num_frames_ego + 1:] *= 0
 
     history_vels_mps, future_vels_mps = compute_agent_velocity(history_coords_offset, future_coords_offset, step_time)
 

--- a/l5kit/l5kit/tests/artefacts/config.yaml
+++ b/l5kit/l5kit/tests/artefacts/config.yaml
@@ -3,7 +3,9 @@
 model_params:
   model_architecture: "resnet50"
 
+  history_num_frames_ego: 0  # this will also create raster history (we need to remove the raster from train/eval dataset - only visualization)
   history_num_frames: 0
+  history_num_frames_agents: 3
   future_num_frames: 50
   step_time: 0.1
   render_ego_history: True
@@ -43,3 +45,24 @@ raster_params:
   # Set it to False for models trained before v1.1.0-25-g3c517f0 (December 2020).
   # In that case visualisation will be flipped (we've removed the flip there) but the model's input will be correct.
   set_origin_to_bottom: True
+
+###################
+## VectorNet Params
+data_generation_params:
+  # maximum number of other agents to take (if less will be padded)
+  other_agents_num: 30
+  # maximum distance from AoI for another agent to be picked
+  max_agents_distance: 35
+  # Parameters defining which and how many lanes to be retrieved
+  lane_params:
+    # maximum number of lanes to take into account
+    # if less they will be padded; if more the closest to AoI are picked
+    max_num_lanes: 30
+    # max number of points per lane
+    max_points_per_lane: 20
+    # max number of points per crosswalk
+    max_points_per_crosswalk: 20
+    # maximum radius around the AoI for which we retrieve
+    max_retrieval_distance_m: 35
+    # max number of crosswalks
+    max_num_crosswalks: 20

--- a/l5kit/l5kit/tests/dataset/dataset_test.py
+++ b/l5kit/l5kit/tests/dataset/dataset_test.py
@@ -5,8 +5,9 @@ import pytest
 from torch.utils.data import DataLoader, Dataset, Subset
 
 from l5kit.data import ChunkedDataset, LocalDataManager
-from l5kit.dataset import AgentDataset, EgoDataset
+from l5kit.dataset import AgentDataset, EgoDataset, EgoDatasetVectorized
 from l5kit.rasterization import build_rasterizer, RenderContext, StubRasterizer
+from l5kit.vectorization.vectorizer_builder import build_vectorizer
 
 
 def check_sample(cfg: dict, dataset: Dataset) -> None:
@@ -101,4 +102,20 @@ def test_no_rast_dataset(
     for idx in indexes:
         data = dataset[idx]
         assert "image" not in data
+    check_torch_loading(dataset)
+
+
+@pytest.mark.parametrize("history_num_frames_ego", [0, 1, 2, 3, 4])
+@pytest.mark.parametrize("history_num_frames_agents", [0, 1, 2, 3, 4])
+def test_vector_ego(zarr_dataset: ChunkedDataset, dmg: LocalDataManager, cfg: dict, history_num_frames_ego: int,
+                    history_num_frames_agents: int) -> None:
+    cfg["model_params"]["history_num_frames_ego"] = history_num_frames_ego
+    cfg["model_params"]["history_num_frames_agents"] = history_num_frames_agents
+
+    vect = build_vectorizer(cfg, dmg)
+    dataset = EgoDatasetVectorized(cfg, zarr_dataset, vect)
+    indexes = [0, 1, 10, -1]
+    for idx in indexes:
+        # TODO (@lberg): check shapes
+        dataset[idx]
     check_torch_loading(dataset)

--- a/l5kit/l5kit/tests/dataset/dataset_test.py
+++ b/l5kit/l5kit/tests/dataset/dataset_test.py
@@ -116,6 +116,5 @@ def test_vector_ego(zarr_dataset: ChunkedDataset, dmg: LocalDataManager, cfg: di
     dataset = EgoDatasetVectorized(cfg, zarr_dataset, vect)
     indexes = [0, 1, 10, -1]
     for idx in indexes:
-        # TODO (@lberg): check shapes
         dataset[idx]
     check_torch_loading(dataset)

--- a/l5kit/l5kit/tests/vectorization/vectorizer_test.py
+++ b/l5kit/l5kit/tests/vectorization/vectorizer_test.py
@@ -1,0 +1,44 @@
+from l5kit.sampling.agent_sampling_vectorized import generate_agent_sample_vectorized
+import pytest
+from l5kit.data import ChunkedDataset, LocalDataManager, get_frames_slice_from_scenes
+from l5kit.vectorization.vectorizer_builder import build_vectorizer
+
+
+@pytest.mark.parametrize("history_num_frames_ego", [0, 1, 2, 3, 4])
+@pytest.mark.parametrize("history_num_frames_agents", [0, 1, 2, 3, 4])
+def test_vectorizer_output_shape(zarr_dataset: ChunkedDataset, dmg: LocalDataManager, cfg: dict,
+                                 history_num_frames_ego: int, history_num_frames_agents: int) -> None:
+    cfg["model_params"]["history_num_frames_ego"] = history_num_frames_ego
+    cfg["model_params"]["history_num_frames_agents"] = history_num_frames_agents
+    max_history_num_frames = max(history_num_frames_ego, history_num_frames_agents)
+    num_agents = cfg["data_generation_params"]["other_agents_num"]
+
+    frames = zarr_dataset.frames[get_frames_slice_from_scenes(zarr_dataset.scenes[0])]
+    data = generate_agent_sample_vectorized(0, frames, zarr_dataset.agents, zarr_dataset.tl_faces, None,
+                                            history_num_frames_ego=cfg["model_params"]["history_num_frames_ego"],
+                                            history_num_frames_agents=cfg["model_params"]["history_num_frames_agents"],
+                                            future_num_frames=cfg["model_params"]["future_num_frames"],
+                                            step_time=cfg["model_params"]["step_time"],
+                                            filter_agents_threshold=cfg["raster_params"]["filter_agents_threshold"],
+                                            vectorizer=build_vectorizer(cfg, dmg))
+
+    assert data["history_positions"].shape == (max_history_num_frames + 1, 2)
+    assert data["history_yaws"].shape == (max_history_num_frames + 1, 1)
+    assert data["history_extents"].shape == (max_history_num_frames + 1, 2)
+    assert data["history_availabilities"].shape == (max_history_num_frames + 1,)
+
+    assert data["all_other_agents_history_positions"].shape == (num_agents, max_history_num_frames + 1, 2)
+    assert data["all_other_agents_history_yaws"].shape == (num_agents, max_history_num_frames + 1, 1)
+    assert data["all_other_agents_history_extents"].shape == (num_agents, max_history_num_frames + 1, 2)
+    assert data["all_other_agents_history_availability"].shape == (num_agents, max_history_num_frames + 1,)
+
+    assert data["target_positions"].shape == (cfg["model_params"]["future_num_frames"], 2)
+    assert data["target_yaws"].shape == (cfg["model_params"]["future_num_frames"], 1)
+    assert data["target_extents"].shape == (cfg["model_params"]["future_num_frames"], 2)
+    assert data["target_availabilities"].shape == (cfg["model_params"]["future_num_frames"],)
+
+    assert data["all_other_agents_future_positions"].shape == (num_agents, cfg["model_params"]["future_num_frames"], 2)
+    assert data["all_other_agents_future_yaws"].shape == (num_agents, cfg["model_params"]["future_num_frames"], 1)
+    assert data["all_other_agents_future_extents"].shape == (num_agents, cfg["model_params"]["future_num_frames"], 2)
+    assert data["all_other_agents_future_availability"].shape == (num_agents, cfg["model_params"]["future_num_frames"],)
+    assert data["all_other_agents_types"].shape == (num_agents,)


### PR DESCRIPTION
Implement hierarchy for `Dataset`.

This PR introduces the following hierarchy:
- `BaseEgoDataset`: this class is not concerned with rasterisation or vectorisation, but only defines methods to get indices and subdataset. It defines a `get_frame` method which will be used to get the dict of data by calling the sample function
    - `EgoDataset`: ego dataset supporting rasterisation. The name has not been changed for backward compatibility
        - `AgentDataset`: agent dataset supporting rasterisation. The name has not been changed for backward compatibility
    - `EgoDatasetVectorized`: ego dataset supporting vectorisation

This is still not ideal (as a lot of code would be replicated if we wanted to implement `AgentDatasetVectorized`). We should prefer modularisation over inheritance.

Also, the sample function is now built from a method which can be changed through inheritance.